### PR TITLE
fix: respec special characters inside string

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -11,6 +11,20 @@ const indent = docBuilders.indent;
 const hardline = docBuilders.hardline;
 const softline = docBuilders.softline;
 
+const makeString = util.makeString;
+
+function stringEscape(str) {
+  return str
+    .replace(/[\\]/g, "\\\\")
+    .replace(/["]/g, '\\"')
+    .replace(/[/]/g, "\\/")
+    .replace(/[\b]/g, "\\b")
+    .replace(/[\f]/g, "\\f")
+    .replace(/[\n]/g, "\\n")
+    .replace(/[\r]/g, "\\r")
+    .replace(/[\t]/g, "\\t");
+}
+
 // polyfill for node 4
 function includes(array, val) {
   return array.indexOf(val) !== -1;
@@ -218,7 +232,7 @@ function printExpression(path, options, print) {
         // use setting from options. need to figure out how this works w/ complex strings and interpolation
         // also need to figure out splitting long strings
         const quote = node.isDoubleQuote ? '"' : "'";
-        return quote + node.value + quote;
+        return makeString(stringEscape(node.value), quote, true);
       }
       case "number":
         return node.value;

--- a/tests/literals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/literals/__snapshots__/jsfmt.spec.js.snap
@@ -12,6 +12,15 @@ $silent = @$foo;
 $nowdoc = <<<'EOL'
 "test" foo
 EOL;
+$newline = "hello\\nworld";
+$win_newline = "hello\\r\\nworld";
+$tab = "hello\\tworld";
+$backslash = "hello\\\\world";
+$slash = "hello/world";
+$single_quotes_with_double_quotes = '"hello world"';
+$single_quotes_with_single_quotes = '\\'hello world\\'';
+$double_quotes_with_single_quotes = "'hello world'";
+$double_quotes_with_double_quotes = "\\"hello world\\"";
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 $boolean_test_true = true;
@@ -23,4 +32,13 @@ $silent = @$foo;
 $nowdoc = <<<'EOL'
 "test" foo
 EOL;
+$newline = "hello\\nworld";
+$win_newline = "hello\\r\\nworld";
+$tab = "hello\\tworld";
+$backslash = "hello\\\\world";
+$slash = "hello/world";
+$single_quotes_with_double_quotes = '"hello world"';
+$single_quotes_with_single_quotes = '\\'hello world\\'';
+$double_quotes_with_single_quotes = "'hello world'";
+$double_quotes_with_double_quotes = "\\"hello world\\"";
 `;

--- a/tests/literals/literals.php
+++ b/tests/literals/literals.php
@@ -9,3 +9,12 @@ $silent = @$foo;
 $nowdoc = <<<'EOL'
 "test" foo
 EOL;
+$newline = "hello\nworld";
+$win_newline = "hello\r\nworld";
+$tab = "hello\tworld";
+$backslash = "hello\\world";
+$slash = "hello/world";
+$single_quotes_with_double_quotes = '"hello world"';
+$single_quotes_with_single_quotes = '\'hello world\'';
+$double_quotes_with_single_quotes = "'hello world'";
+$double_quotes_with_double_quotes = "\"hello world\"";


### PR DESCRIPTION
Fixes #29

Why parse by default don't escape special characters :confused: 