### PR TITLE
fix: use printLines for namespace nodes

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -376,13 +376,11 @@ function printStatement(path, options, print) {
           "namespace ",
           node.name,
           ";",
-          node.children.length > 0 ? hardline : "",
-          concat(
-            path.map(
-              childrenPath => concat([hardline, print(childrenPath)]),
-              "children"
-            )
-          )
+          // don't know why we need 2 line breaks here, but 1 doesn't work
+          node.children.length > 0 ? concat([hardline, hardline]) : "",
+          path.call(childrenPath => {
+            return printLines(childrenPath, options, print);
+          }, "children")
         ]);
       default:
         return "Have not implemented block kind " + node.kind + " yet.";

--- a/tests/formatting/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/formatting/__snapshots__/jsfmt.spec.js.snap
@@ -33,6 +33,7 @@ namespace Vendor\\Package;
 use FooInterface;
 use BarClass as Bar;
 use OtherVendor\\OtherPackage\\BazClass;
+
 class Foo extends Bar implements FooInterface
 {
 

--- a/tests/include/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/include/__snapshots__/jsfmt.spec.js.snap
@@ -2,12 +2,16 @@
 
 exports[`include.php 1`] = `
 <?php
+namespace \\test\\testing;
+
 include "test.php";
 include_once "other.php";
 require "test/test.php";
 require_once "other/other.php";
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
+namespace \\test\\testing;
+
 include "test.php";
 include_once "other.php";
 require "test/test.php";

--- a/tests/include/include.php
+++ b/tests/include/include.php
@@ -1,4 +1,6 @@
 <?php
+namespace \test\testing;
+
 include "test.php";
 include_once "other.php";
 require "test/test.php";


### PR DESCRIPTION
Addressing #68 

[Namespace](https://github.com/glayzzle/php-parser/blob/master/docs/AST.md#namespace) is just an extension of a block node - we need to use `printLines` to actually print the `children` attribute