### PR TITLE
fix: remove extra line in top of body class

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -471,7 +471,6 @@ function printStatement(path, options, print) {
           ),
           hardline,
           "{",
-          hardline,
           indent(
             concat([
               hardline,

--- a/tests/class/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/class/__snapshots__/jsfmt.spec.js.snap
@@ -93,11 +93,12 @@ abstract class ReallyReallyReallyLongClassName extends AbstractModelFactoryResou
 }
 
 $this->something->method($argument, $this->more->stuff($this->even->more->things->complicatedMethod()));
+
+class A {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 class Foo extends Bar implements Baz, Buzz
 {
-
   public $test;
 
   public function test()
@@ -118,7 +119,6 @@ abstract class ReallyReallyReallyLongClassName
   extends AbstractModelFactoryResourceController
   implements TooMuchObjectOrientation, ThisIsMadness
 {
-
   // variable doc
   public $test;
   public $other = 1;
@@ -207,5 +207,10 @@ $this->something->method(
   $argument,
   $this->more->stuff($this->even->more->things->complicatedMethod())
 );
+
+class A
+{
+
+}
 
 `;

--- a/tests/class/class.php
+++ b/tests/class/class.php
@@ -90,3 +90,5 @@ abstract class ReallyReallyReallyLongClassName extends AbstractModelFactoryResou
 }
 
 $this->something->method($argument, $this->more->stuff($this->even->more->things->complicatedMethod()));
+
+class A {}

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -74,7 +74,6 @@ $hi = 1;
  */
 class Foo
 {
-
   /** @var string|null $title contains a title for the Foo with a max. length of 24 characters */
   protected $title = null;
 

--- a/tests/constants/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/constants/__snapshots__/jsfmt.spec.js.snap
@@ -25,7 +25,6 @@ $test = OTHER_TEST_CONSTANT;
 
 class Constants
 {
-
   const TEST_CLASS_CONSTANT = 3;
 
   public static function testClassConstant()

--- a/tests/formatting/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/formatting/__snapshots__/jsfmt.spec.js.snap
@@ -36,7 +36,6 @@ use OtherVendor\\OtherPackage\\BazClass;
 
 class Foo extends Bar implements FooInterface
 {
-
   public function sampleMethod($a, $b = null)
   {
     if ($a === $b) {

--- a/tests/traits/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/traits/__snapshots__/jsfmt.spec.js.snap
@@ -61,7 +61,6 @@ trait C extends A implements B {
 
 class ImplementingClass
 {
-
   use testTrait, otherTrait;
   use testTrait, implementingTrait {
     A::testFunction insteadof C;
@@ -72,7 +71,6 @@ class ImplementingClass
 
 class ShortImplementingClass
 {
-
   use testTrait { A::testFunction insteadof C; }
 }
 


### PR DESCRIPTION
Information:
- Laravel - __No__ (https://github.com/laravel/framework/blob/5.6/src/Illuminate/Foundation/Application.php)
- Symfony - __No__ (https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/HttpKernel.php)
- Yii2 - __No__ (https://github.com/yiisoft/yii2/blob/master/framework/BaseYii.php)