### PR TITLE
fix: multiline comments

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1111,6 +1111,7 @@ function printNode(path, options, print) {
       return "return";
     case "doc": {
       let canAddEmptyLine = false;
+      // @TODO: need refactor after resolve https://github.com/glayzzle/php-parser/issues/114
       return node.isDoc
         ? concat([
             "/**",
@@ -1135,7 +1136,23 @@ function printNode(path, options, print) {
             node.lines.length > 1 ? hardline : "",
             " */"
           ])
-        : join(hardline, node.lines.map(comment => concat(["// ", comment])));
+        : join(
+            hardline,
+            node.lines.map(comment =>
+              concat([
+                comment.split(/\n/).length > 1
+                  ? concat(["/*", comment[0] === "*" ? "" : " "])
+                  : "// ",
+                comment,
+                comment.split(/\n/).length > 1
+                  ? concat([
+                      comment[comment.length - 1] === "*" ? "" : " ",
+                      "*/"
+                    ])
+                  : ""
+              ])
+            )
+          );
     }
     case "entry":
       return concat([

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -45,6 +45,23 @@ class Foo
         $this->title = $title;
     }
 }
+
+/*********************
+ * Some long comment *
+ *********************/
+
+// This is a one-line c++ style comment
+
+/* This is a multi line comment
+   yet another line of comment */
+
+/*
+This is a multiple-lines comment block
+that spans over multiple
+lines
+*/
+
+# This is a one-line shell-style comment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 /** @var int $int This is a counter. */
@@ -90,5 +107,16 @@ class Foo
     $this->title = $title;
   }
 }
+
+/*********************
+ * Some long comment *
+ *********************/
+// This is a one-line c++ style comment
+/* This is a multi line comment
+   yet another line of comment */
+/* This is a multiple-lines comment block
+that spans over multiple
+lines */
+// This is a one-line shell-style comment
 
 `;

--- a/tests/comments/comments.php
+++ b/tests/comments/comments.php
@@ -42,3 +42,20 @@ class Foo
         $this->title = $title;
     }
 }
+
+/*********************
+ * Some long comment *
+ *********************/
+
+// This is a one-line c++ style comment
+
+/* This is a multi line comment
+   yet another line of comment */
+
+/*
+This is a multiple-lines comment block
+that spans over multiple
+lines
+*/
+
+# This is a one-line shell-style comment


### PR DESCRIPTION
fixes #30

Also i think we should don't touch content inside comments. Prettier don't do this and we should not do this.
If comment `//Foo` we should print `//Foo`, don't add example space. Let's do this in other PR