### PR TITLE
tests: long `foreach`

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -908,13 +908,15 @@ function printStatement(path, options, print) {
               concat([
                 softline,
                 path.call(print, "source"),
-                " as",
                 line,
+                "as ",
                 node.key
-                  ? join(" => ", [
-                      path.call(print, "key"),
-                      path.call(print, "value")
-                    ])
+                  ? indent(
+                      join(concat([" =>", line]), [
+                        path.call(print, "key"),
+                        path.call(print, "value")
+                      ])
+                    )
                   : path.call(print, "value")
               ])
             ),

--- a/tests/foreach/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/foreach/__snapshots__/jsfmt.spec.js.snap
@@ -20,6 +20,9 @@ foreach ( $test as $i ) {
 
 foreach ($test as $i)
     $test2 = $i;
+
+foreach (['foo' => ['very-very-very-long-value'], 'bar' => ['very-very-very-long-value']] as $veryVeryVeryVeryVeryVeryVeryVeryLongKey) {}
+foreach (['foo' => ['very-very-very-long-value'], 'bar' => ['very-very-very-long-value']] as $veryVeryVeryVeryVeryVeryVeryVeryLongKey => $veryVeryVeryVeryVeryVeryVeryVeryLongValue) {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 foreach ($test as $i) {
@@ -27,8 +30,9 @@ foreach ($test as $i) {
 }
 
 foreach (
-    $really_really_really_really_really_long_array as
-    $key => $really_really_really_long_value
+    $really_really_really_really_really_long_array
+    as $key =>
+        $really_really_really_long_value
 ) {
     $test3 = $really_really_really_long_value;
 }
@@ -43,6 +47,26 @@ foreach ($test as $i) {
 
 foreach ($test as $i) {
     $test2 = $i;
+}
+
+foreach (
+    [
+        'foo' => ['very-very-very-long-value'],
+        'bar' => ['very-very-very-long-value']
+    ]
+    as $veryVeryVeryVeryVeryVeryVeryVeryLongKey
+) {
+
+}
+foreach (
+    [
+        'foo' => ['very-very-very-long-value'],
+        'bar' => ['very-very-very-long-value']
+    ]
+    as $veryVeryVeryVeryVeryVeryVeryVeryLongKey =>
+        $veryVeryVeryVeryVeryVeryVeryVeryLongValue
+) {
+
 }
 
 `;

--- a/tests/foreach/foreach.php
+++ b/tests/foreach/foreach.php
@@ -17,3 +17,6 @@ foreach ( $test as $i ) {
 
 foreach ($test as $i)
     $test2 = $i;
+
+foreach (['foo' => ['very-very-very-long-value'], 'bar' => ['very-very-very-long-value']] as $veryVeryVeryVeryVeryVeryVeryVeryLongKey) {}
+foreach (['foo' => ['very-very-very-long-value'], 'bar' => ['very-very-very-long-value']] as $veryVeryVeryVeryVeryVeryVeryVeryLongKey => $veryVeryVeryVeryVeryVeryVeryVeryLongValue) {}


### PR DESCRIPTION
@czosel @mgrip @vjeux @azz That do you think about this output? Should we print `as` always newline when group breaks?