### PR TITLE
tests: empty lines between opening and closing braces

### DIFF
--- a/tests/class/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/class/__snapshots__/jsfmt.spec.js.snap
@@ -185,6 +185,18 @@ $this->something->method($argument, $this->more->stuff($this->even->more->things
 class A {}
 
 $someVar = new ReaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaalyLongClassName();
+
+class ClassName
+
+extends ParentClass
+
+implements \\ArrayAccess, \\Countable
+
+{
+
+    // constants, properties, methods
+
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 class Foo extends Bar implements Baz, Buzz
@@ -354,5 +366,10 @@ class A
 }
 
 $someVar = new ReaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaalyLongClassName();
+
+class ClassName extends ParentClass implements \\ArrayAccess, \\Countable
+{
+    // constants, properties, methods
+}
 
 `;

--- a/tests/class/class.php
+++ b/tests/class/class.php
@@ -125,3 +125,15 @@ $this->something->method($argument, $this->more->stuff($this->even->more->things
 class A {}
 
 $someVar = new ReaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaalyLongClassName();
+
+class ClassName
+
+extends ParentClass
+
+implements \ArrayAccess, \Countable
+
+{
+
+    // constants, properties, methods
+
+}


### PR DESCRIPTION
From PSR-12:

> The opening brace for the class MUST go on its own line; the closing brace for the class MUST go on the next line after the body.

> Opening braces MUST be on their own line and MUST NOT be preceded or followed by a blank line.

> Closing braces MUST be on their own line and MUST NOT be preceded by a blank line.

