### PR TITLE
tests: multiple properties and methods

### DIFF
--- a/tests/class/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/class/__snapshots__/jsfmt.spec.js.snap
@@ -197,6 +197,8 @@ implements \\ArrayAccess, \\Countable
     // constants, properties, methods
 
 }
+
+class FooBar { public $property; public $property2; public function method() {} public function method2() {} }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 class Foo extends Bar implements Baz, Buzz
@@ -370,6 +372,20 @@ $someVar = new ReaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaalyLongClassName(
 class ClassName extends ParentClass implements \\ArrayAccess, \\Countable
 {
     // constants, properties, methods
+}
+
+class FooBar
+{
+    public $property;
+    public $property2;
+    public function method()
+    {
+
+    }
+    public function method2()
+    {
+
+    }
 }
 
 `;

--- a/tests/class/class.php
+++ b/tests/class/class.php
@@ -137,3 +137,5 @@ implements \ArrayAccess, \Countable
     // constants, properties, methods
 
 }
+
+class FooBar { public $property; public $property2; public function method() {} public function method2() {} }


### PR DESCRIPTION
From PSR-12:

> There MUST NOT be more than one property declared per statement.