### PR TITLE
tests: spaces in function and method declaration

### DIFF
--- a/tests/class/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/class/__snapshots__/jsfmt.spec.js.snap
@@ -199,6 +199,11 @@ implements \\ArrayAccess, \\Countable
 }
 
 class FooBar { public $property; public $property2; public function method() {} public function method2() {} }
+
+class FooBarFoo
+{
+    public function fooBarBaz ( $x,$y ,$z, $foo , $bar ) { /* Comment */ }
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 class Foo extends Bar implements Baz, Buzz
@@ -385,6 +390,14 @@ class FooBar
     public function method2()
     {
 
+    }
+}
+
+class FooBarFoo
+{
+    public function fooBarBaz($x, $y, $z, $foo, $bar)
+    {
+        // Comment
     }
 }
 

--- a/tests/class/class.php
+++ b/tests/class/class.php
@@ -139,3 +139,8 @@ implements \ArrayAccess, \Countable
 }
 
 class FooBar { public $property; public $property2; public function method() {} public function method2() {} }
+
+class FooBarFoo
+{
+    public function fooBarBaz ( $x,$y ,$z, $foo , $bar ) { /* Comment */ }
+}

--- a/tests/functions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/functions/__snapshots__/jsfmt.spec.js.snap
@@ -68,6 +68,8 @@ function two_args($x, $y) {
     return $x;
 }
 
+function two_args_other ( $x,$y ,$z, $foo , $bar ) { return $x; }
+
 function reeeeeeeeeeaaaaaaaallllllllyyyyyy_llloooooooonnnnnnggggg($soooooooooooo_looooooooonnnng, $eeeeeeeeevvveeeeeeeennnn_loooooonnngggeeeerrrr) {
     return $soooooooooooo_looooooooonnnng;
 }
@@ -156,6 +158,11 @@ function return_x($x)
 }
 
 function two_args($x, $y)
+{
+    return $x;
+}
+
+function two_args_other($x, $y, $z, $foo, $bar)
 {
     return $x;
 }

--- a/tests/functions/functions.php
+++ b/tests/functions/functions.php
@@ -12,6 +12,8 @@ function two_args($x, $y) {
     return $x;
 }
 
+function two_args_other ( $x,$y ,$z, $foo , $bar ) { return $x; }
+
 function reeeeeeeeeeaaaaaaaallllllllyyyyyy_llloooooooonnnnnnggggg($soooooooooooo_looooooooonnnng, $eeeeeeeeevvveeeeeeeennnn_loooooonnngggeeeerrrr) {
     return $soooooooooooo_looooooooonnnng;
 }


### PR DESCRIPTION
PSR-12:

> Method and function names MUST NOT be declared with a space after the method name. The opening brace MUST go on its own line, and the closing brace MUST go on the next line following the body. There MUST NOT be a space after the opening parenthesis, and there MUST NOT be a space before the closing parenthesis.