### PR TITLE
tests: spaces in function and method declaration

### DIFF
--- a/tests/call/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/call/__snapshots__/jsfmt.spec.js.snap
@@ -7,6 +7,9 @@ func($a, $b, $c);
 func(...$a);
 func($a, ...$b);
 $foo->func();
+func( $arg1,$arg2 ,$arg3, $arg4 , $arg5 );
+$foo -> bar ( $arg1,$arg2 ,$arg3, $arg4 , $arg5 ) ;
+Foo :: bar( $arg1,$arg2 ,$arg3, $arg4 , $arg5 ) ;
 
 $db->Execute($sql, [
     $foo,
@@ -99,6 +102,9 @@ func($a, $b, $c);
 func(...$a);
 func($a, ...$b);
 $foo->func();
+func($arg1, $arg2, $arg3, $arg4, $arg5);
+$foo->bar($arg1, $arg2, $arg3, $arg4, $arg5);
+Foo::bar($arg1, $arg2, $arg3, $arg4, $arg5);
 
 $db->Execute($sql, [
     $foo,

--- a/tests/call/call.php
+++ b/tests/call/call.php
@@ -4,6 +4,9 @@ func($a, $b, $c);
 func(...$a);
 func($a, ...$b);
 $foo->func();
+func( $arg1,$arg2 ,$arg3, $arg4 , $arg5 );
+$foo -> bar ( $arg1,$arg2 ,$arg3, $arg4 , $arg5 ) ;
+Foo :: bar( $arg1,$arg2 ,$arg3, $arg4 , $arg5 ) ;
 
 $db->Execute($sql, [
     $foo,


### PR DESCRIPTION
From PSR-12:
> When making a method or function call, there MUST NOT be a space between the method or function name and the opening parenthesis, there MUST NOT be a space after the opening parenthesis, and there MUST NOT be a space before the closing parenthesis. In the argument list, there MUST NOT be a space before each comma, and there MUST be one space after each comma.