### PR TITLE
Remove linebreak in propertylookup on left side of assignment

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -354,13 +354,14 @@ function printExpression(path, options, print) {
   function printLookup(node) {
     switch (node.kind) {
       case "propertylookup": {
+        const canBreak = path.stack.indexOf("left") === -1;
         return group(
           concat([
             path.call(print, "what"),
             "->",
             indent(
               concat([
-                softline,
+                canBreak ? softline : "",
                 wrapPropertyLookup(node, path.call(print, "offset"))
               ])
             )
@@ -922,17 +923,21 @@ function printStatement(path, options, print) {
   }
 
   switch (node.kind) {
-    case "assign":
+    case "assign": {
+      const canBreak =
+        node.right.kind === "bin" ||
+        ["number", "string"].indexOf(node.right.kind) > -1;
       return group(
         concat([
           path.call(print, "left"),
           " ",
           node.operator,
-          node.right.kind === "bin"
+          canBreak
             ? indent(concat([line, path.call(print, "right")]))
             : concat([" ", path.call(print, "right")])
         ])
       );
+    }
     case "if": {
       const handleIfAlternate = alternate => {
         if (!alternate) {

--- a/src/printer.js
+++ b/src/printer.js
@@ -323,6 +323,16 @@ function wrapPropertyLookup(node, doc) {
   return addCurly ? concat(["{", doc, "}"]) : doc;
 }
 
+function isPropertyLookupChain(node) {
+  if (node.kind !== "propertylookup") {
+    return false;
+  }
+  if (node.what.kind === "variable") {
+    return true;
+  }
+  return isPropertyLookupChain(node.what);
+}
+
 const expressionKinds = [
   "array",
   "variable",
@@ -926,7 +936,8 @@ function printStatement(path, options, print) {
     case "assign": {
       const canBreak =
         node.right.kind === "bin" ||
-        ["number", "string"].indexOf(node.right.kind) > -1;
+        ["number", "string"].indexOf(node.right.kind) > -1 ||
+        isPropertyLookupChain(node.right);
       return group(
         concat([
           path.call(print, "left"),

--- a/tests/propertylookup/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/propertylookup/__snapshots__/jsfmt.spec.js.snap
@@ -12,6 +12,13 @@ $b = $this->{foo['bar']};
 $b = $this->{'foo' . $bar};
 $b = $this->{self::STUFF};
 $object = $this->{'bar' . $foo}->buzz();
+
+$this->loooooooooooongloooooooooooongloooooooooooonglookup = "teeeeeeeeeeeeeeeeeeeeest";
+$this->loooooooooooong->loooooooooooong->loooooooooooong->lookup = "teeeeeeeeeeest";
+$this->loooooooooooong->loooooooooooong->loooooooooooong->lookup = $other->looooooooooong->stuff;
+$this->loooooooooooong->lookup = (int) $this->getRequest()->getParam(
+  'instance-resource-id'
+);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 $a = $obj->value;
@@ -23,5 +30,16 @@ $b = $this->{foo['bar']};
 $b = $this->{'foo' . $bar};
 $b = $this->{self::STUFF};
 $object = $this->{'bar' . $foo}->buzz();
+
+$this->loooooooooooongloooooooooooongloooooooooooonglookup =
+    "teeeeeeeeeeeeeeeeeeeeest";
+$this->loooooooooooong->loooooooooooong->loooooooooooong->lookup =
+    "teeeeeeeeeeest";
+$this->loooooooooooong->loooooooooooong->loooooooooooong->lookup = $other->
+    looooooooooong->
+    stuff;
+$this->loooooooooooong->lookup = (int) $this->getRequest()->getParam(
+    'instance-resource-id'
+);
 
 `;

--- a/tests/propertylookup/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/propertylookup/__snapshots__/jsfmt.spec.js.snap
@@ -35,9 +35,8 @@ $this->loooooooooooongloooooooooooongloooooooooooonglookup =
     "teeeeeeeeeeeeeeeeeeeeest";
 $this->loooooooooooong->loooooooooooong->loooooooooooong->lookup =
     "teeeeeeeeeeest";
-$this->loooooooooooong->loooooooooooong->loooooooooooong->lookup = $other->
-    looooooooooong->
-    stuff;
+$this->loooooooooooong->loooooooooooong->loooooooooooong->lookup =
+    $other->looooooooooong->stuff;
 $this->loooooooooooong->lookup = (int) $this->getRequest()->getParam(
     'instance-resource-id'
 );

--- a/tests/propertylookup/propertylookup.php
+++ b/tests/propertylookup/propertylookup.php
@@ -9,3 +9,10 @@ $b = $this->{foo['bar']};
 $b = $this->{'foo' . $bar};
 $b = $this->{self::STUFF};
 $object = $this->{'bar' . $foo}->buzz();
+
+$this->loooooooooooongloooooooooooongloooooooooooonglookup = "teeeeeeeeeeeeeeeeeeeeest";
+$this->loooooooooooong->loooooooooooong->loooooooooooong->lookup = "teeeeeeeeeeest";
+$this->loooooooooooong->loooooooooooong->loooooooooooong->lookup = $other->looooooooooong->stuff;
+$this->loooooooooooong->lookup = (int) $this->getRequest()->getParam(
+  'instance-resource-id'
+);


### PR DESCRIPTION
This also adds a linebreak after an assignment operator if there is a literal on the right.

Fixes #150 