### PR TITLE
fix: don't break identifier

### DIFF
--- a/src/clean.js
+++ b/src/clean.js
@@ -30,22 +30,54 @@ function clean(node, newObj) {
   }
 
   // All reserved words should be lowercase case
-  if (node.kind === "identifier" && typeof node.name === "string") {
-    const lowerCasedName = node.name.toLowerCase();
-    const isLowerCase =
+  if (node.kind === "identifier" && node.name.toLowerCase() === "null") {
+    return "null";
+  }
+  if (node.kind === "staticlookup" && node.what.kind === "identifier") {
+    const lowerCasedName = node.what.name.toLowerCase();
+    const isLowerCase = ["self", "parent"].includes(lowerCasedName);
+    newObj.what.name = isLowerCase ? lowerCasedName : node.what.name;
+  }
+  if (node.kind === "parameter" && node.type.kind === "identifier") {
+    const lowerCasedName = node.type.name.toLowerCase();
+    if (
       [
+        "\\array",
+        "\\callable",
         "int",
         "float",
         "bool",
         "string",
-        "null",
         "void",
         "iterable",
         "object",
         "self"
-      ].indexOf(lowerCasedName) !== -1;
-
-    newObj.name = isLowerCase ? lowerCasedName : node.name;
+      ].includes(lowerCasedName)
+    ) {
+      newObj.type.name = lowerCasedName.replace("\\", "");
+    }
+  }
+  if (
+    (node.kind === "method" || node.kind === "function") &&
+    node.type.kind === "identifier"
+  ) {
+    const lowerCasedName = node.type.name.toLowerCase();
+    if (
+      [
+        "\\array",
+        "\\callable",
+        "int",
+        "float",
+        "bool",
+        "string",
+        "void",
+        "iterable",
+        "object",
+        "self"
+      ].includes(lowerCasedName)
+    ) {
+      newObj.type.name = lowerCasedName.replace("\\", "");
+    }
   }
 
   if (["Location", "Position"].includes(node.constructor.name)) {

--- a/src/printer.js
+++ b/src/printer.js
@@ -351,6 +351,18 @@ const expressionKinds = [
 function printExpression(path, options, print) {
   const node = path.getValue();
   const lookupKinds = ["propertylookup", "staticlookup", "offsetlookup"];
+  function printWhat(path) {
+    return path.call(childPath => {
+      const node = childPath.getValue();
+      if (node.kind === "identifier") {
+        const lowerCasedName = node.name.toLowerCase();
+        if (["self", "parent"].includes(lowerCasedName)) {
+          return lowerCasedName;
+        }
+      }
+      return print(childPath);
+    }, "what");
+  }
   function printLookup(node) {
     switch (node.kind) {
       case "propertylookup": {
@@ -368,11 +380,7 @@ function printExpression(path, options, print) {
         );
       }
       case "staticlookup":
-        return concat([
-          path.call(print, "what"),
-          "::",
-          path.call(print, "offset")
-        ]);
+        return concat([printWhat(path), "::", path.call(print, "offset")]);
       case "offsetlookup": {
         const isOffsetNumberNode = node.offset && node.offset.kind === "number";
 
@@ -781,6 +789,32 @@ function printStatement(path, options, print) {
       ]);
     }
 
+    function printType(path) {
+      return path.call(childPath => {
+        const node = childPath.getValue();
+        if (node.kind === "identifier") {
+          const lowerCasedName = node.name.toLowerCase();
+          if (
+            [
+              "\\array",
+              "\\callable",
+              "int",
+              "float",
+              "bool",
+              "string",
+              "void",
+              "iterable",
+              "object",
+              "self"
+            ].includes(lowerCasedName)
+          ) {
+            return lowerCasedName.replace("\\", "");
+          }
+        }
+        return print(childPath);
+      }, "type");
+    }
+
     switch (node.kind) {
       case "class":
         return printDeclarationBlock({
@@ -812,7 +846,7 @@ function printStatement(path, options, print) {
           declaration: concat(["function ", node.byref ? "&" : "", node.name]),
           argumentsList: path.map(print, "arguments"),
           returnTypeContents: node.type
-            ? concat([node.nullable ? "?" : "", path.call(print, "type")])
+            ? concat([node.nullable ? "?" : "", printType(path)])
             : "",
           bodyContents: node.body ? path.call(print, "body") : ""
         });
@@ -829,14 +863,14 @@ function printStatement(path, options, print) {
           ]),
           argumentsList: path.map(print, "arguments"),
           returnTypeContents: node.type
-            ? concat([node.nullable ? "?" : "", path.call(print, "type")])
+            ? concat([node.nullable ? "?" : "", printType(path)])
             : "",
           bodyContents: node.body ? path.call(print, "body") : ""
         });
       case "parameter": {
         const name = concat([
           node.nullable ? "?" : "",
-          node.type ? concat([path.call(print, "type"), " "]) : "",
+          node.type ? concat([printType(path), " "]) : "",
           node.variadic ? "..." : "",
           node.byref ? "&" : "",
           "$",
@@ -1372,29 +1406,10 @@ function printNode(path, options, print) {
   }
   switch (node.kind) {
     case "identifier": {
-      // this is a hack until https://github.com/glayzzle/php-parser/issues/113 is resolved
-      // for reserved words we prefer lowercase case
-      if (node.name === "\\array") {
-        return "array";
-      } else if (node.name === "\\callable") {
-        return "callable";
+      if (node.name.toLowerCase() === "null") {
+        return "null";
       }
-
-      const lowerCasedName = node.name.toLowerCase();
-      const isLowerCase =
-        [
-          "int",
-          "float",
-          "bool",
-          "string",
-          "null",
-          "void",
-          "iterable",
-          "object",
-          "self"
-        ].indexOf(lowerCasedName) !== -1;
-
-      return isLowerCase ? lowerCasedName : node.name;
+      return node.name;
     }
     case "case":
       return concat([

--- a/tests/case/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/case/__snapshots__/jsfmt.spec.js.snap
@@ -234,6 +234,21 @@ FINAL CLASS MyClass EXTENDS Bar IMPLEMENTS iTemplate
     {
         // Nothing
     }
+
+    public function parentTest()
+    {
+        $array = [];
+        echo $array[iNt];
+        echo $array[sElF];
+        echo $array[pArEnT];
+        echo $array[aRaRay];
+        echo $array[oBjEcT];
+
+        SELF::who();
+        STATIC $a = 'test';
+
+        return PARENT::who();
+    }
 }
 
 __HALT_COMPILER();
@@ -480,6 +495,21 @@ final class MyClass extends Bar implements iTemplate
     ): void
     {
         // Nothing
+    }
+
+    public function parentTest()
+    {
+        $array = [];
+        echo $array[iNt];
+        echo $array[sElF];
+        echo $array[pArEnT];
+        echo $array[aRaRay];
+        echo $array[oBjEcT];
+
+        self::who();
+        static $a = 'test';
+
+        return parent::who();
     }
 }
 

--- a/tests/case/case.php
+++ b/tests/case/case.php
@@ -231,6 +231,21 @@ FINAL CLASS MyClass EXTENDS Bar IMPLEMENTS iTemplate
     {
         // Nothing
     }
+
+    public function parentTest()
+    {
+        $array = [];
+        echo $array[iNt];
+        echo $array[sElF];
+        echo $array[pArEnT];
+        echo $array[aRaRay];
+        echo $array[oBjEcT];
+
+        SELF::who();
+        STATIC $a = 'test';
+
+        return PARENT::who();
+    }
 }
 
 __HALT_COMPILER();


### PR DESCRIPTION
We can't change case or other changes in `identifier`, because it is can break code `$array[oBjEcT]` where `object` is constant