### PR TITLE
feat: improve `static` output

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1261,7 +1261,7 @@ function printStatement(path, options, print) {
           "static",
           indent(
             concat([
-              line,
+              " ",
               join(
                 concat([",", line]),
                 path.map(item => {

--- a/tests/static/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/static/__snapshots__/jsfmt.spec.js.snap
@@ -9,8 +9,7 @@ static $testReallyReallyLong = 1, $someOtherReallyReallyLongVariable = 2, $oneMo
 <?php
 static $a, $b;
 static $c = 2;
-static
-    $testReallyReallyLong = 1,
+static $testReallyReallyLong = 1,
     $someOtherReallyReallyLongVariable = 2,
     $oneMoreReallyLongVariable = 3;
 


### PR DESCRIPTION
As `global`, also as `var a,b,c,d;` in `prettier`