### PR TITLE
feat: improve `inline` output

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,12 @@
 "use strict";
 
+const docUtils = require("prettier").doc.utils;
+
+// polyfill for node 4
+function includes(array, val) {
+  return array.indexOf(val) !== -1;
+}
+
 function printNumber(rawNumber) {
   return (
     rawNumber
@@ -130,9 +137,209 @@ function shouldFlatten(parentOp, nodeOp) {
   return true;
 }
 
+function nodeHasStatement(node) {
+  return [
+    "block",
+    "program",
+    "namespace",
+    "class",
+    "interface",
+    "trait",
+    "traituse",
+    "declare"
+  ].includes(node.kind);
+}
+
+function shouldRemoveLines(path) {
+  return isPrevNodeInline(path) && isNextNodeInline(path);
+}
+
+function removeNewlines(doc) {
+  return docUtils.mapDoc(doc, d => {
+    if (d.type === "line") {
+      return d.soft ? "" : " ";
+    } else if (d.type === "if-break") {
+      return d.flatContents || "";
+    }
+    return d;
+  });
+}
+
+function getNodeListProperty(node) {
+  const body = node.children || node.body || node.adaptations;
+  return Array.isArray(body) ? body : null;
+}
+
+function getParentNodeListProperty(path) {
+  const parent = path.getParentNode();
+  if (!parent) {
+    return null;
+  }
+  return getNodeListProperty(parent);
+}
+
+function getNodeIndex(path) {
+  const body = getParentNodeListProperty(path);
+  if (!body) {
+    return -1;
+  }
+  return body.indexOf(path.getValue());
+}
+
+function getLast(arr) {
+  if (arr.length > 0) {
+    return arr[arr.length - 1];
+  }
+  return null;
+}
+
+function isLastStatement(path) {
+  const body = getParentNodeListProperty(path);
+  if (!body) {
+    return true;
+  }
+  const node = path.getValue();
+  return body[body.length - 1] === node;
+}
+
+function isFirstNodeInParentProgramNode(path) {
+  const parentNode = path.getParentNode();
+  const nodeIndex = getNodeIndex(path);
+  const isParentProgramNode = parentNode && parentNode.kind === "program";
+  return isParentProgramNode && nodeIndex === 0;
+}
+
+function isFirstNodeInParentNode(path) {
+  const nodeIndex = getNodeIndex(path);
+  return nodeIndex === 0;
+}
+
+function isLastNodeInParentNode(path) {
+  const parentNodeBody = getParentNodeListProperty(path);
+  const nodeIndex = getNodeIndex(path);
+  return parentNodeBody && nodeIndex === parentNodeBody.length - 1;
+}
+
+function isPrevNodeInline(path) {
+  const nodeIndex = getNodeIndex(path);
+  const parentNodeBody = getParentNodeListProperty(path);
+  const prevNode = nodeIndex !== -1 && parentNodeBody[nodeIndex - 1];
+  return prevNode && prevNode.kind === "inline";
+}
+
+function isNextNodeInline(path) {
+  const parentNodeBody = getParentNodeListProperty(path);
+  const nodeIndex = getNodeIndex(path);
+  const nextNode = nodeIndex !== -1 && parentNodeBody[nodeIndex + 1];
+  return nextNode && nextNode.kind === "inline";
+}
+
+function lineShouldHaveStartPHPTag(path) {
+  return isFirstNodeInParentProgramNode(path) || isPrevNodeInline(path);
+}
+
+function lineShouldEndWithSemicolon(path) {
+  const parentNode = path.getParentNode();
+  if (!parentNode) {
+    return false;
+  }
+  if (!nodeHasStatement(parentNode)) {
+    return false;
+  }
+  const node = path.getValue();
+  const semiColonWhitelist = [
+    "assign",
+    "return",
+    "break",
+    "continue",
+    "call",
+    "pre",
+    "post",
+    "bin",
+    "unary",
+    "yield",
+    "yieldfrom",
+    "echo",
+    "list",
+    "print",
+    "isset",
+    "retif",
+    "unset",
+    "empty",
+    "traitprecedence",
+    "traitalias",
+    "constant",
+    "classconstant",
+    "exit",
+    "global",
+    "static",
+    "include",
+    "goto",
+    "throw",
+    "magic",
+    "new",
+    "eval"
+  ];
+  if (node.kind === "traituse") {
+    return !node.adaptations;
+  }
+  if (node.kind === "method" && node.isAbstract) {
+    return true;
+  }
+  if (node.kind === "method") {
+    const parent = path.getParentNode();
+    if (parent && parent.kind === "interface") {
+      return true;
+    }
+  }
+  return includes(semiColonWhitelist, node.kind);
+}
+
+function lineShouldEndWithHardline(path) {
+  const node = path.getValue();
+  const nodeIndex = getNodeIndex(path);
+  return (
+    nodeIndex !== -1 &&
+    !isLastStatement(path) &&
+    node.kind !== "case" &&
+    !isNextNodeInline(path)
+  );
+}
+
+function lineShouldHaveEndPHPTag(path) {
+  return isNextNodeInline(path);
+}
+
+function fileShouldEndWithHardline(path) {
+  const node = path.getValue();
+  const isProgramNode = node.kind === "program";
+  return (
+    isProgramNode && node.children[node.children.length - 1].kind !== "inline"
+  );
+}
+
 module.exports = {
+  includes,
   printNumber,
   stringEscape,
   getPrecedence,
-  shouldFlatten
+  shouldFlatten,
+  nodeHasStatement,
+  getNodeListProperty,
+  getParentNodeListProperty,
+  getNodeIndex,
+  getLast,
+  isLastStatement,
+  isFirstNodeInParentProgramNode,
+  isFirstNodeInParentNode,
+  isLastNodeInParentNode,
+  isPrevNodeInline,
+  isNextNodeInline,
+  lineShouldHaveStartPHPTag,
+  lineShouldEndWithSemicolon,
+  lineShouldEndWithHardline,
+  lineShouldHaveEndPHPTag,
+  fileShouldEndWithHardline,
+  shouldRemoveLines,
+  removeNewlines
 };

--- a/tests/inline/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/inline/__snapshots__/jsfmt.spec.js.snap
@@ -36,6 +36,18 @@ function inlineNested1() {
     <span>Hello World!</span>
     </div><?php
 }
+
+function inlineMultipleStatements() {
+    $a = 1;
+    ?>
+    <span>Hello World!</span>
+    <?php
+    $b = 1;
+    ?>
+    <span>Hello World!</span>
+    <?php
+    $c = 1;
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 function inline()
@@ -75,6 +87,15 @@ function inlineNested1()
     </div><?php
 }
 
+function inlineMultipleStatements()
+{
+    $a = 1;
+    ?>    <span>Hello World!</span>
+    <?php $b = 1; ?>    <span>Hello World!</span>
+    <?php
+    $c = 1;
+}
+
 `;
 
 exports[`mixed.php 1`] = `
@@ -92,11 +113,57 @@ exports[`mixed.php 1`] = `
 echo 'foo';
 echo 'bar';
 ?>
+<div class="<?php echo $class; ?>"></div>
+<div>
+  <h1>
+    <?php print_welcome_message(); ?>
+  </h1>
+</div>
+<div id="results">
+  <table class="sortable">
+    <?php $results = $statement->fetchAll(PDO::FETCH_ASSOC); ?>
+    <?php do { ?>
+      <tr>
+        <?php for ($i = 0; $i < count($columns); $i++): ?>
+          <td><?php echo $row[$i] ?></td>
+        <?php endfor; ?>
+      </tr>
+    <?php } while (($row = next($results)) != false); ?>
+  </table>
+</div>
+<div id="results">
+  <table class="sortable">
+    <?php foreach ($statement->fetchAll(PDO::FETCH_ASSOC) as $row): ?>
+      <tr>
+        <?php foreach ($row as $element): ?>
+          <td><?php echo $element ?></td>
+        <?php endforeach; ?>
+      </tr>
+    <?php endforeach; ?>
+  </table>
+</div>
+<div>
+  <?php switch($variable):
+  case 1: ?>
+      <div>Newspage</div>
+      <?php break; ?>
+  <?php case 2: ?>
+      </div>Forum<div>
+  <?php break; ?>
+  <?php endswitch; ?>
+</div>
+<ul>
+  <?php for($i=1;$i<=5;$i++){ ?>
+      <li>Menu Item <?php echo $i; ?></li>
+  <?php } ?>
+</ul>
+<?php while(true): ?>
+  <span>Text</span>
+<?php endwhile; ?>
+<h1>Head</h1>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <p>Test.</p>
-<?php
-echo 'String.';
-?><p>Test.</p>
+<?php echo 'String.'; ?><p>Test.</p>
 <?php
 if ($expression == true):
     ?>  <p>Test.</p>
@@ -110,6 +177,66 @@ echo '<input type="hidden" value="' . htmlspecialchars($data) . '" />';
 <?php
 echo 'foo';
 echo 'bar';
+?><div class="<?php echo $class; ?>"></div>
+<div>
+  <h1>
+    <?php print_welcome_message(); ?>  </h1>
+</div>
+<div id="results">
+  <table class="sortable">
+    <?php $results = $statement->fetchAll(
+    PDO::FETCH_ASSOC
+); ?>    <?php do { ?>      <tr>
+        <?php for ($i = 0; $i < count(
+            $columns
+        ); $i++): ?>          <td><?php echo $row[$i]; ?></td>
+        <?php endfor; ?>      </tr>
+    <?php } while (($row = next(
+            $results
+        )) != false); ?>  </table>
+</div>
+<div id="results">
+  <table class="sortable">
+    <?php foreach ($statement->fetchAll(
+        PDO::FETCH_ASSOC
+    ) as $row): ?>      <tr>
+        <?php foreach ($row as $element): ?>          <td><?php echo $element; ?></td>
+        <?php endforeach; ?>      </tr>
+    <?php endforeach; ?>  </table>
+</div>
+<div>
+  <?php switch ($variable): case 1: ?>      <div>Newspage</div>
+      <?php break; ?>  <?php case 2: ?>      </div>Forum<div>
+  <?php break; ?>  <?php endswitch; ?></div>
+<ul>
+  <?php for ($i = 1; $i <= 5; $i++) { ?>      <li>Menu Item <?php echo $i; ?></li>
+  <?php } ?></ul>
+<?php while (true): ?>  <span>Text</span>
+<?php endwhile; ?><h1>Head</h1>
+
+`;
+
+exports[`mixed-1.php 1`] = `
+<?php
+$a = 1;
+?>
+<div>Foo</div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<?php
+$a = 1;
+?><div>Foo</div>
+
+`;
+
+exports[`mixed-2.php 1`] = `
+<div>Foo</div>
+<?php
+$a = 1;
+?>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<div>Foo</div>
+<?php
+$a = 1;
 
 `;
 

--- a/tests/inline/inline.php
+++ b/tests/inline/inline.php
@@ -33,3 +33,15 @@ function inlineNested1() {
     <span>Hello World!</span>
     </div><?php
 }
+
+function inlineMultipleStatements() {
+    $a = 1;
+    ?>
+    <span>Hello World!</span>
+    <?php
+    $b = 1;
+    ?>
+    <span>Hello World!</span>
+    <?php
+    $c = 1;
+}

--- a/tests/inline/mixed-1.php
+++ b/tests/inline/mixed-1.php
@@ -1,0 +1,4 @@
+<?php
+$a = 1;
+?>
+<div>Foo</div>

--- a/tests/inline/mixed-2.php
+++ b/tests/inline/mixed-2.php
@@ -1,0 +1,4 @@
+<div>Foo</div>
+<?php
+$a = 1;
+?>

--- a/tests/inline/mixed.php
+++ b/tests/inline/mixed.php
@@ -12,3 +12,51 @@
 echo 'foo';
 echo 'bar';
 ?>
+<div class="<?php echo $class; ?>"></div>
+<div>
+  <h1>
+    <?php print_welcome_message(); ?>
+  </h1>
+</div>
+<div id="results">
+  <table class="sortable">
+    <?php $results = $statement->fetchAll(PDO::FETCH_ASSOC); ?>
+    <?php do { ?>
+      <tr>
+        <?php for ($i = 0; $i < count($columns); $i++): ?>
+          <td><?php echo $row[$i] ?></td>
+        <?php endfor; ?>
+      </tr>
+    <?php } while (($row = next($results)) != false); ?>
+  </table>
+</div>
+<div id="results">
+  <table class="sortable">
+    <?php foreach ($statement->fetchAll(PDO::FETCH_ASSOC) as $row): ?>
+      <tr>
+        <?php foreach ($row as $element): ?>
+          <td><?php echo $element ?></td>
+        <?php endforeach; ?>
+      </tr>
+    <?php endforeach; ?>
+  </table>
+</div>
+<div>
+  <?php switch($variable):
+  case 1: ?>
+      <div>Newspage</div>
+      <?php break; ?>
+  <?php case 2: ?>
+      </div>Forum<div>
+  <?php break; ?>
+  <?php endswitch; ?>
+</div>
+<ul>
+  <?php for($i=1;$i<=5;$i++){ ?>
+      <li>Menu Item <?php echo $i; ?></li>
+  <?php } ?>
+</ul>
+<?php while(true): ?>
+  <span>Text</span>
+<?php endwhile; ?>
+<h1>Head</h1>


### PR DESCRIPTION
It is not easy :+1:  Why remove `printLines`?
1. One place where we put `;` and `newlines`.
2. Easy reading.
3. For future: here we can add/remove unnecessary nodes(example - `parens` around arithmetic operation how it do `prettier` or better output `inline`).

After add `\n` in `php-parser` (already added, need just update) output will be more better :+1: 