### PR TITLE
fix: better output `eval` node

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1367,7 +1367,14 @@ function printStatement(path, options, print) {
     case "halt":
       return concat(["__halt_compiler();", node.after.replace(/\n$/, "")]);
     case "eval":
-      return concat(["eval(", path.call(print, "source"), ")"]);
+      return group(
+        concat([
+          "eval(",
+          indent(concat([softline, path.call(print, "source")])),
+          softline,
+          ")"
+        ])
+      );
     default:
       return "Have not implemented statement kind " + node.kind + " yet.";
   }

--- a/tests/eval/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/eval/__snapshots__/jsfmt.spec.js.snap
@@ -4,9 +4,19 @@ exports[`eval.php 1`] = `
 <?php
 eval('return 1;');
 eval("return $a;");
+eval("$veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongVariableName = $veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongVariableValue;");
+eval("VeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongText" . "VeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongText" . "VeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongText");
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 eval('return 1;');
 eval("return $a;");
+eval(
+    "$veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongVariableName = $veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongVariableValue;"
+);
+eval(
+    "VeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongText" .
+    "VeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongText" .
+    "VeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongText"
+);
 
 `;

--- a/tests/eval/eval.php
+++ b/tests/eval/eval.php
@@ -1,3 +1,5 @@
 <?php
 eval('return 1;');
 eval("return $a;");
+eval("$veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongVariableName = $veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongVariableValue;");
+eval("VeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongText" . "VeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongText" . "VeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongText");


### PR DESCRIPTION
Rare use case, but we need good output :smile: 