### PR TITLE
feat: strip leading slash from `use` node

### DIFF
--- a/src/clean.js
+++ b/src/clean.js
@@ -103,6 +103,14 @@ function clean(node, newObj) {
   if (node.kind === "include" && node.target.kind === "parenthesis") {
     newObj.target = newObj.target.inner;
   }
+
+  if (node.kind === "usegroup" && typeof node.name === "string") {
+    newObj.name = newObj.name.replace(/^\\/, "");
+  }
+
+  if (node.kind === "useitem") {
+    newObj.name = newObj.name.replace(/^\\/, "");
+  }
 }
 
 module.exports = clean;

--- a/src/printer.js
+++ b/src/printer.js
@@ -32,6 +32,7 @@ const fileShouldEndWithHardline = util.fileShouldEndWithHardline;
 const lineShouldHaveEndPHPTag = util.lineShouldHaveEndPHPTag;
 const shouldRemoveLines = util.shouldRemoveLines;
 const removeNewlines = util.removeNewlines;
+const maybeStripLeadingSlashFromUse = util.maybeStripLeadingSlashFromUse;
 
 const makeString = sharedUtil.makeString;
 
@@ -1191,7 +1192,13 @@ function printStatement(path, options, print) {
           node.type ? concat([node.type, " "]) : "",
           indent(
             concat([
-              node.name ? concat([node.name, "\\{", softline]) : "",
+              node.name
+                ? concat([
+                    maybeStripLeadingSlashFromUse(node.name),
+                    "\\{",
+                    softline
+                  ])
+                : "",
               join(
                 concat([",", line]),
                 path.map(item => concat([print(item)]), "items")
@@ -1205,7 +1212,7 @@ function printStatement(path, options, print) {
     case "useitem":
       return concat([
         node.type ? concat([node.type, " "]) : "",
-        node.name,
+        maybeStripLeadingSlashFromUse(node.name),
         node.alias ? concat([" as ", node.alias]) : ""
       ]);
     case "closure":

--- a/src/util.js
+++ b/src/util.js
@@ -352,6 +352,14 @@ function fileShouldEndWithHardline(path) {
   return true;
 }
 
+function maybeStripLeadingSlashFromUse(name) {
+  const nameWithoutLeadingSlash = name.replace(/^\\/, "");
+  if (nameWithoutLeadingSlash.indexOf("\\") !== -1) {
+    return nameWithoutLeadingSlash;
+  }
+  return name;
+}
+
 module.exports = {
   includes,
   printNumber,
@@ -377,5 +385,6 @@ module.exports = {
   lineShouldHaveEndPHPTag,
   fileShouldEndWithHardline,
   shouldRemoveLines,
-  removeNewlines
+  removeNewlines,
+  maybeStripLeadingSlashFromUse
 };

--- a/tests/use/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/use/__snapshots__/jsfmt.spec.js.snap
@@ -30,6 +30,14 @@ use Mizo\\Web\\{
     const JS\\BUAIKUM,
     const JS\\MAUTAM
 };
+use \\Illuminate\\Foundation\\Bootstrap\\BootProviders;
+use function \\some\\Full\\fn_a;
+use const \\My\\Full\\CONSTANT;
+use \\Vendor\\Package\\SomeNamespace\\{
+    SubnamespaceOne\\ClassA
+};
+use Exception;
+use \\Exception;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 namespace foo;
@@ -61,6 +69,12 @@ use Mizo\\Web\\{
     const JS\\BUAIKUM,
     const JS\\MAUTAM
 };
+use Illuminate\\Foundation\\Bootstrap\\BootProviders;
+use function some\\Full\\fn_a;
+use const My\\Full\\CONSTANT;
+use Vendor\\Package\\SomeNamespace\\{SubnamespaceOne\\ClassA};
+use Exception;
+use \\Exception;
 
 `;
 

--- a/tests/use/use.php
+++ b/tests/use/use.php
@@ -27,3 +27,11 @@ use Mizo\Web\{
     const JS\BUAIKUM,
     const JS\MAUTAM
 };
+use \Illuminate\Foundation\Bootstrap\BootProviders;
+use function \some\Full\fn_a;
+use const \My\Full\CONSTANT;
+use \Vendor\Package\SomeNamespace\{
+    SubnamespaceOne\ClassA
+};
+use Exception;
+use \Exception;


### PR DESCRIPTION
From php.net:
> Note that for namespaced names (fully qualified namespace names containing namespace separator, such as Foo\Bar as opposed to global names that do not, such as FooBar), the leading backslash is unnecessary and not recommended, as import names must be fully qualified, and are not processed relative to the current namespace.