### PR TITLE
tests: curly brace for access array

### DIFF
--- a/tests/array/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/array/__snapshots__/jsfmt.spec.js.snap
@@ -336,6 +336,7 @@ $this->long->expression->before->array->statesArray[
   $state->getCirculationStateId()
 ] = $state->getName();
 $arr[ ] = 1;
+$arr{"x"} = 42;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 $test = array(1, 2, 3, 4, "test");
@@ -422,5 +423,6 @@ $this->long->expression->before->array->statesArray[
     $state->getCirculationStateId()
 ] = $state->getName();
 $arr[] = 1;
+$arr["x"] = 42;
 
 `;

--- a/tests/array/arrays.php
+++ b/tests/array/arrays.php
@@ -333,3 +333,4 @@ $this->long->expression->before->array->statesArray[
   $state->getCirculationStateId()
 ] = $state->getName();
 $arr[ ] = 1;
+$arr{"x"} = 42;


### PR DESCRIPTION
Just tests.
> Note:
Both square brackets and curly braces can be used interchangeably for accessing array elements (e.g. $array[42] and $array{42} will both do the same thing in the example above).