### PR TITLE
fix: print comments in array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,9 @@ const printers = {
     massageAstNode: clean,
     // @TODO: determine if it makes sense to abstract this into a "getChildNodes" util function
     getCommentChildNodes(node) {
+      if (node.kind === "array") {
+        return node.items;
+      }
       if (node.kind === "assign") {
         return [node.left, node.right];
       }

--- a/src/printer.js
+++ b/src/printer.js
@@ -553,11 +553,12 @@ function printExpression(path, options, print) {
           node.shortForm ? "[" : "array(",
           indent(
             concat([
-              softline,
+              node.comments && node.comments.length > 0 ? hardline : softline,
               join(concat([",", line]), path.map(print, "items"))
             ])
           ),
           ifBreak(shouldPrintComma(options) ? "," : ""),
+          comments.printDanglingComments(path, options, /* sameIndent */ true),
           softline,
           node.shortForm ? "]" : ")"
         ])
@@ -1540,11 +1541,20 @@ function printNode(path, options, print) {
       }
       return concat(parts);
     }
-    case "entry":
+    case "entry": {
+      const dangling = comments.printDanglingComments(
+        path,
+        options,
+        /* sameLine */ true
+      );
+      const printedComments = dangling ? concat([hardline, dangling]) : "";
+
       return concat([
         node.key ? concat([path.call(print, "key"), " => "]) : "",
-        path.call(print, "value")
+        path.call(print, "value"),
+        printedComments
       ]);
+    }
     case "traituse":
       return group(
         concat([

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,100 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`array.php 1`] = `
+<?php
+$array = [/* comment */];
+$array = [
+    // comment
+];
+$array = [ // comment
+    // comment
+    1, // comment
+    2 // comment
+    // comment
+];
+$array = [ /* comment */
+    /* comment */
+    /* comment */ 1 /* comment */ , /* comment */
+    /* comment */ 2 /* comment */
+    /* comment */
+    /* comment */ ];
+$array = [ /* comment */
+    /* comment */
+    /* comment */ "foo" /* comment */ => /* comment */ "bar", /* comment */
+    /* comment */ "bar" /* comment */ => /* comment */ "foo" /* comment */
+    /* comment */
+    /* comment */ ];
+$array = [ // test
+    1, 2, 3, 4, 5, 6
+];
+$array = [
+    1, 2, 3, 4, 5, 6 // test
+];
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<?php
+$array = [
+    /* comment */
+];
+$array = [
+    // comment
+];
+$array = [
+    // comment
+    // comment
+    1,
+    // comment
+    2
+    // comment
+    // comment
+];
+$array = [
+    /* comment */
+    /* comment */
+    /* comment */
+    1
+    /* comment */, /* comment */
+    /* comment */
+    2
+    /* comment */
+    /* comment */
+    /* comment */
+];
+$array = [
+    /* comment */
+    /* comment */
+    /* comment */
+    "foo" => "bar"
+    /* comment */
+    /* comment */, /* comment */
+    /* comment */
+    "bar" => "foo"
+    /* comment */
+    /* comment */
+    /* comment */
+    /* comment */
+    /* comment */
+];
+$array = [
+    // test
+    1,
+    2,
+    3,
+    4,
+    5,
+    6
+];
+$array = [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6
+    // test
+];
+
+`;
+
 exports[`class.php 1`] = `
 <?php
 namespace Test\\test\\test;

--- a/tests/comments/array.php
+++ b/tests/comments/array.php
@@ -1,0 +1,29 @@
+<?php
+$array = [/* comment */];
+$array = [
+    // comment
+];
+$array = [ // comment
+    // comment
+    1, // comment
+    2 // comment
+    // comment
+];
+$array = [ /* comment */
+    /* comment */
+    /* comment */ 1 /* comment */ , /* comment */
+    /* comment */ 2 /* comment */
+    /* comment */
+    /* comment */ ];
+$array = [ /* comment */
+    /* comment */
+    /* comment */ "foo" /* comment */ => /* comment */ "bar", /* comment */
+    /* comment */ "bar" /* comment */ => /* comment */ "foo" /* comment */
+    /* comment */
+    /* comment */ ];
+$array = [ // test
+    1, 2, 3, 4, 5, 6
+];
+$array = [
+    1, 2, 3, 4, 5, 6 // test
+];


### PR DESCRIPTION
Some comment will be printed better (as do prettier). We need implement `printComments` function as in prettier or move in shared utils. Let's merge this as is and in next PR fix comment places.