### PR TITLE
fix: add string escape for encapsed

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -477,7 +477,10 @@ function printExpression(path, options, print) {
         // @TODO: for now just reusing double/single quote preference from doc. could eventually
         // use setting from options. need to figure out how this works w/ complex strings and interpolation
         // also need to figure out splitting long strings
-        const quote = node.isDoubleQuote ? '"' : "'";
+        let quote = node.isDoubleQuote ? '"' : "'";
+        if (path.getParentNode().kind === "encapsed") {
+          quote = "";
+        }
         return makeString(stringEscape(node.value), quote, false);
       }
       case "number":
@@ -494,7 +497,9 @@ function printExpression(path, options, print) {
             path.map(valuePath => {
               const node = valuePath.getValue();
               if (node.kind === "string") {
-                return node.value;
+                return valuePath.getParentNode().type === "heredoc"
+                  ? node.value
+                  : print(valuePath);
               } else if (node.kind === "variable") {
                 if (typeof node.name === "object") {
                   return concat(["${", path.call(print, "name"), "}"]);

--- a/src/printer.js
+++ b/src/printer.js
@@ -33,7 +33,6 @@ const {
   printNumber,
   shouldFlatten,
   shouldRemoveLines,
-  stringEscape,
   removeNewlines,
   maybeStripLeadingSlashFromUse,
   fileShouldEndWithHardline
@@ -478,10 +477,19 @@ function printExpression(path, options, print) {
         // use setting from options. need to figure out how this works w/ complex strings and interpolation
         // also need to figure out splitting long strings
         let quote = node.isDoubleQuote ? '"' : "'";
+        let stringValue = node.raw;
         if (path.getParentNode().kind === "encapsed") {
           quote = "";
+        } else {
+          // if this is not part of an encapsed node, we need to strip out the quotes from the raw value
+          if (['"', "'"].includes(stringValue[0])) {
+            stringValue = stringValue.substr(1);
+          }
+          if (['"', "'"].includes(stringValue[stringValue.length - 1])) {
+            stringValue = stringValue.substr(0, stringValue.length - 1);
+          }
         }
-        return makeString(stringEscape(node.value), quote, false);
+        return makeString(stringValue, quote, false);
       }
       case "number":
         return printNumber(node.value);

--- a/src/util.js
+++ b/src/util.js
@@ -20,6 +20,7 @@ function printNumber(rawNumber) {
 }
 
 function stringEscape(str) {
+  debugger;
   return str.replace(/[\n\r\t\v\f\u001b\\]/g, (character, index) => {
     switch (character) {
       case "\n":

--- a/src/util.js
+++ b/src/util.js
@@ -19,6 +19,7 @@ function printNumber(rawNumber) {
   );
 }
 
+// @TODO: if we're using the "raw" value from the parser, do we need this?
 function stringEscape(str) {
   return str.replace(/[\n\r\t\v\f\u001b\\]/g, (character, index) => {
     switch (character) {

--- a/src/util.js
+++ b/src/util.js
@@ -20,7 +20,6 @@ function printNumber(rawNumber) {
 }
 
 function stringEscape(str) {
-  debugger;
   return str.replace(/[\n\r\t\v\f\u001b\\]/g, (character, index) => {
     switch (character) {
       case "\n":

--- a/tests/echo/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/echo/__snapshots__/jsfmt.spec.js.snap
@@ -68,7 +68,9 @@ echo "Loop start!\\n", sleep(1);
 <?php
 echo "Hello World";
 
-echo "This spans\\nmultiple lines. The newlines will be\\noutput as well";
+echo "This spans
+multiple lines. The newlines will be
+output as well";
 
 echo "This spans\\nmultiple lines. The newlines will be\\noutput as well.";
 

--- a/tests/list/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/list/__snapshots__/jsfmt.spec.js.snap
@@ -34,13 +34,11 @@ $info = array('coffee', 'brown', 'caffeine');
 
 // Listing all the variables
 list($drink, $color, $power) = $info;
-echo "$drink is $color and $power makes it special.
-";
+echo "$drink is $color and $power makes it special.\\n";
 
 // Listing some of them
 list($drink, , $power) = $info;
-echo "$drink has $power.
-";
+echo "$drink has $power.\\n";
 
 // TODO: unncoment after resolve https://github.com/glayzzle/php-parser/issues/137
 // Or let's skip to only the third one

--- a/tests/print/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/print/__snapshots__/jsfmt.spec.js.snap
@@ -60,7 +60,9 @@ print "Hello World";
 
 print "print() also works without parentheses.";
 
-print "This spans\\nmultiple lines. The newlines will be\\noutput as well";
+print "This spans
+multiple lines. The newlines will be
+output as well";
 
 print "This spans\\nmultiple lines. The newlines will be\\noutput as well.";
 

--- a/tests/string/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/string/__snapshots__/jsfmt.spec.js.snap
@@ -61,6 +61,9 @@ $string = "I'd like an {\${beers::$ale}}\\n";
 $test = "\\\\";
 $test = '\\\\';
 printf("Query run in $queryTimeTaken seconds.\\n");
+$test = "You can also have embedded\\n newlines in
+strings this way as it is
+okay to do";
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 $string = 'this is a simple string';
@@ -69,7 +72,7 @@ $string = 'this is a simple string';
 // okay to do';
 $string = 'Arnold once said: "I\\'ll be back"';
 $string = 'You deleted C:\\\\*.*?';
-$string = 'You deleted C:\\\\*.*?';
+$string = 'You deleted C:\\*.*?';
 // $string = 'This will not expand: \\n a newline';
 $string = 'Variables do not $expand $either';
 $string = 'qwe{$a}rty';
@@ -126,5 +129,9 @@ $string = "I'd like an \${beers::$ale}\\n";
 $test = "\\\\";
 $test = '\\\\';
 printf("Query run in $queryTimeTaken seconds.\\n");
+$test =
+    "You can also have embedded\\n newlines in
+strings this way as it is
+okay to do";
 
 `;

--- a/tests/string/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/string/__snapshots__/jsfmt.spec.js.snap
@@ -61,10 +61,6 @@ $string = "I'd like an {\${beers::$ale}}\\n";
 $test = "\\\\";
 $test = '\\\\';
 printf("Query run in $queryTimeTaken seconds.\\n");
-$query =
-    'SELECT *
-     FROM users
-     WHERE u.id IS NULL';
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 $string = 'this is a simple string';
@@ -130,6 +126,5 @@ $string = "I'd like an \${beers::$ale}\\n";
 $test = "\\\\";
 $test = '\\\\';
 printf("Query run in $queryTimeTaken seconds.\\n");
-$query = 'SELECT *\\n     FROM users\\n     WHERE u.id IS NULL';
 
 `;

--- a/tests/string/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/string/__snapshots__/jsfmt.spec.js.snap
@@ -60,6 +60,11 @@ $string = "I'd like an {\${beers::softdrink}}\\n";
 $string = "I'd like an {\${beers::$ale}}\\n";
 $test = "\\\\";
 $test = '\\\\';
+printf("Query run in $queryTimeTaken seconds.\\n");
+$query =
+    'SELECT *
+     FROM users
+     WHERE u.id IS NULL';
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 $string = 'this is a simple string';
@@ -120,11 +125,11 @@ $string = "This is the value of the var named by the return value of getName(): 
     $arg3
 )}";
 // $string = "This is the value of the var named by the return value of \\$object->getName(): {\${$object->getName()}}";
-$string = "I'd like an \${beers::softdrink}
-";
-$string = "I'd like an \${beers::$ale}
-";
+$string = "I'd like an \${beers::softdrink}\\n";
+$string = "I'd like an \${beers::$ale}\\n";
 $test = "\\\\";
 $test = '\\\\';
+printf("Query run in $queryTimeTaken seconds.\\n");
+$query = 'SELECT *\\n     FROM users\\n     WHERE u.id IS NULL';
 
 `;

--- a/tests/string/string.php
+++ b/tests/string/string.php
@@ -58,7 +58,3 @@ $string = "I'd like an {${beers::$ale}}\n";
 $test = "\\";
 $test = '\\';
 printf("Query run in $queryTimeTaken seconds.\n");
-$query =
-    'SELECT *
-     FROM users
-     WHERE u.id IS NULL';

--- a/tests/string/string.php
+++ b/tests/string/string.php
@@ -57,3 +57,8 @@ $string = "I'd like an {${beers::softdrink}}\n";
 $string = "I'd like an {${beers::$ale}}\n";
 $test = "\\";
 $test = '\\';
+printf("Query run in $queryTimeTaken seconds.\n");
+$query =
+    'SELECT *
+     FROM users
+     WHERE u.id IS NULL';

--- a/tests/string/string.php
+++ b/tests/string/string.php
@@ -58,3 +58,6 @@ $string = "I'd like an {${beers::$ale}}\n";
 $test = "\\";
 $test = '\\';
 printf("Query run in $queryTimeTaken seconds.\n");
+$test = "You can also have embedded\n newlines in
+strings this way as it is
+okay to do";


### PR DESCRIPTION
https://github.com/prettier/plugin-php/issues/29

Unfortunately I don't think we can fix https://github.com/prettier/plugin-php/issues/253 right now. Maybe we can utilize the `raw` attribute from the parser? But `node.value` is exactly the same whether its a literal line break or escaped