### PR TITLE
fix: don't print empty line in body of control structures for leading comments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,8 +85,8 @@ const printers = {
         {
           kinds: ["foreach"],
           children: {
-            listNodes: ["children"],
-            nodes: ["key", "source", "value"]
+            listNodes: [],
+            nodes: ["key", "source", "value", "body"]
           }
         },
         {

--- a/src/printer.js
+++ b/src/printer.js
@@ -988,7 +988,6 @@ function printStatement(path, options, print) {
       node.shortForm ? ":" : " {",
       indent(
         concat([
-          node.comments && node.comments.length > 0 ? hardline : "",
           comments.printDanglingComments(path, options, true),
           node[bodyProperty].kind !== "block" ||
           (node[bodyProperty].children &&

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -382,7 +382,6 @@ class Foo
 # This is a one-line shell-style comment
 
 for ($i = 0; $i < 10; $i++) {
-
     // some comment
     $a = 1;
     $b = 2;
@@ -413,19 +412,23 @@ $constraint = new UniqueEntity(array(
 
 `;
 
-exports[`dangling_for.php 1`] = `
+exports[`do.php 1`] = `
 <?php
-for // comment
-(;;);
-
-for /* comment */(;;);
+// Comment
+do { // Comment
+    // Comment
+    echo $i; // Comment
+    // Comment
+} while ($i > 0); // Comment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
-// comment
-for (;;);
-
-/* comment */
-for (;;);
+// Comment
+do {
+    // Comment
+    // Comment
+    echo $i; // Comment
+    // Comment
+} while ($i > 0); // Comment
 
 `;
 
@@ -488,6 +491,57 @@ function testFunction(
 
 `;
 
+exports[`for.php 1`] = `
+<?php
+for // Comment
+(;;);
+
+for /* Comment */(;;);
+
+// Comment
+for ($i = 1; $i <= 10; $i++) { // Comment
+    // Comment
+    echo $i; // Comment
+    // Comment
+} // Comment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<?php
+// Comment
+for (;;);
+
+/* Comment */
+for (;;);
+
+// Comment
+for ($i = 1; $i <= 10; $i++) {
+    // Comment
+    // Comment
+    echo $i; // Comment
+    // Comment
+} // Comment
+
+`;
+
+exports[`foreach.php 1`] = `
+<?php
+// Comment
+foreach ($iterable as $value) { // Comment
+    // Comment
+    echo 'Foo'; // Comment
+    // Comment
+} // Comment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<?php
+// Comment
+foreach ($iterable as $value) {
+    // Comment
+    // Comment
+    echo 'Foo'; // Comment
+    // Comment
+} // Comment
+
+`;
+
 exports[`functions.php 1`] = `
 <?php
 
@@ -505,6 +559,44 @@ function foo(
     /* comment */
 
 }
+
+`;
+
+exports[`if.php 1`] = `
+<?php
+// Comment
+if (1) { // Comment
+    // Comment
+    echo "Foo"; // Comment
+    // Comment
+} elseif (2) { // Comment
+    // Comment
+    echo "Bar";
+    // Comment
+} else { // Comment
+    // Comment
+    echo "FooBar";
+    // Comment
+} // Comment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<?php
+// Comment
+if (1) {
+    // Comment
+    // Comment
+    echo "Foo"; // Comment
+    // Comment
+} elseif (2) {
+    // Comment
+    // Comment
+    echo "Bar";
+    // Comment
+} else {
+    // Comment
+    // Comment
+    echo "FooBar";
+    // Comment
+} // Comment
 
 `;
 
@@ -551,4 +643,63 @@ exports[`no_code.php 1`] = `
  * @package WooCommerce/Templates
  * @version 2.0.0
  */
+`;
+
+exports[`switch.php 1`] = `
+<?php
+// Comment
+switch ($i) { // Comment
+    // Comment
+    case 0: // Comment
+        // Comment
+        echo "i equals 0"; // Comment
+        // Comment
+        break; // Comment
+        // Comment
+    case 1: // Comment
+        // Comment
+        echo "i equals 1"; // Comment
+        break; // Comment
+        // Comment
+} // Comment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<?php
+// Comment
+switch ($i) {
+    // Comment
+    // Comment
+    case 0: // Comment
+        // Comment
+        echo "i equals 0"; // Comment
+        // Comment
+        break; // Comment
+    // Comment
+    case 1: // Comment
+        // Comment
+        echo "i equals 1";
+        // Comment
+        break; // Comment
+    // Comment
+} // Comment
+
+`;
+
+exports[`while.php 1`] = `
+<?php
+// Comment 1
+while (true) { // Comment 2
+    // Comment 3
+    echo 'Foo'; // Comment 4
+    // Comment 5
+} // Comment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<?php
+// Comment 1
+while (true) {
+    // Comment 2
+    // Comment 3
+    echo 'Foo'; // Comment 4
+    // Comment 5
+} // Comment
+
 `;

--- a/tests/comments/dangling_for.php
+++ b/tests/comments/dangling_for.php
@@ -1,5 +1,0 @@
-<?php
-for // comment
-(;;);
-
-for /* comment */(;;);

--- a/tests/comments/do.php
+++ b/tests/comments/do.php
@@ -1,0 +1,7 @@
+<?php
+// Comment
+do { // Comment
+    // Comment
+    echo $i; // Comment
+    // Comment
+} while ($i > 0); // Comment

--- a/tests/comments/for.php
+++ b/tests/comments/for.php
@@ -1,0 +1,12 @@
+<?php
+for // Comment
+(;;);
+
+for /* Comment */(;;);
+
+// Comment
+for ($i = 1; $i <= 10; $i++) { // Comment
+    // Comment
+    echo $i; // Comment
+    // Comment
+} // Comment

--- a/tests/comments/foreach.php
+++ b/tests/comments/foreach.php
@@ -1,0 +1,7 @@
+<?php
+// Comment
+foreach ($iterable as $value) { // Comment
+    // Comment
+    echo 'Foo'; // Comment
+    // Comment
+} // Comment

--- a/tests/comments/if.php
+++ b/tests/comments/if.php
@@ -1,0 +1,15 @@
+<?php
+// Comment
+if (1) { // Comment
+    // Comment
+    echo "Foo"; // Comment
+    // Comment
+} elseif (2) { // Comment
+    // Comment
+    echo "Bar";
+    // Comment
+} else { // Comment
+    // Comment
+    echo "FooBar";
+    // Comment
+} // Comment

--- a/tests/comments/switch.php
+++ b/tests/comments/switch.php
@@ -1,0 +1,16 @@
+<?php
+// Comment
+switch ($i) { // Comment
+    // Comment
+    case 0: // Comment
+        // Comment
+        echo "i equals 0"; // Comment
+        // Comment
+        break; // Comment
+        // Comment
+    case 1: // Comment
+        // Comment
+        echo "i equals 1"; // Comment
+        break; // Comment
+        // Comment
+} // Comment

--- a/tests/comments/while.php
+++ b/tests/comments/while.php
@@ -1,0 +1,7 @@
+<?php
+// Comment 1
+while (true) { // Comment 2
+    // Comment 3
+    echo 'Foo'; // Comment 4
+    // Comment 5
+} // Comment


### PR DESCRIPTION
fixes #269

Also fix incorrect position comments for `foreach` and rename `dangling_for` to `for`