### PR TITLE
fix: only format printing of comments for docblocks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -206,7 +206,7 @@ const printers = {
             );
           }
 
-          // otherwise we can't be sure about indentationt, so just print as is
+          // otherwise we can't be sure about indentation, so just print as is
           return comment.value;
         }
         case "commentline": {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const print = require("./printer");
 const clean = require("./clean");
 const options = require("./options");
 const comments = require("./comments");
-const { concat, join, hardline } = require("prettier").doc.builders;
+const { join, hardline } = require("prettier").doc.builders;
 
 const languages = [
   {
@@ -189,56 +189,25 @@ const printers = {
             return comment.value;
           }
 
-          // if this is not a doc comment, just print as is, replacing new lines
+          const lines = comment.value.split("\n");
+          // if this is a block comment, handle indentation
           if (
-            !(
-              comment.value.startsWith("/* ") ||
-              comment.value.startsWith("/** ") ||
-              comment.value.startsWith("/*\n") ||
-              comment.value.startsWith("/**\n")
-            )
+            lines
+              .slice(1, lines.length - 1)
+              .every(line => line.trim()[0] === "*")
           ) {
-            return join(hardline, comment.value.split("\n"));
+            return join(
+              hardline,
+              lines.map(
+                (line, index) =>
+                  (index > 0 ? " " : "") +
+                  (index < lines.length - 1 ? line.trim() : line.trimLeft())
+              )
+            );
           }
 
-          // if this is a doc comment, lets try to make it a little pretty
-          const lines = comment.value.split("\n");
-
-          const linesToPrint = [];
-          let canPrintBlankLine = false;
-          lines.forEach((line, index) => {
-            const lineContainsRealText = /[^(*|/|\s)]/.test(line);
-            if (
-              !lineContainsRealText &&
-              canPrintBlankLine &&
-              index < lines.length - 1
-            ) {
-              linesToPrint.push("");
-              canPrintBlankLine = false;
-            } else if (lineContainsRealText) {
-              linesToPrint.push(
-                line
-                  .replace("//", "")
-                  .replace("/*", "")
-                  .replace("*/", "")
-                  .replace("*", "")
-                  .trim()
-              );
-              canPrintBlankLine = true;
-            }
-          });
-          return concat([
-            "/**",
-            hardline,
-            join(
-              hardline,
-              linesToPrint.map(line => {
-                return ` *${line.length > 0 ? ` ${line}` : ""}`;
-              })
-            ),
-            hardline,
-            " */"
-          ]);
+          // otherwise we can't be sure about indentationt, so just print as is
+          return comment.value;
         }
         case "commentline": {
           return comment.value.trimRight();

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -331,6 +331,24 @@ class Test {
       some test
 
   */
+
+  /*
+  <a href="#"
+      class="btn btn-info ladda-button"
+      data-ui-component="unified-modal-opener"
+      data-style="zoom-in"
+      data-title="Title modal"
+      data-size="md"
+      data-header="true"
+      data-footer="false"
+      data-render="contact-form"
+      data-view="Title"
+      >
+      <span class="ladda-label">Modal</span>
+  </a>
+
+  Options: data-render - contact-form, render, template-part
+  */
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 /** @var int $int This is a counter. */
@@ -451,6 +469,24 @@ class Test
 /*
       some test
 
+  */
+
+/*
+  <a href="#"
+      class="btn btn-info ladda-button"
+      data-ui-component="unified-modal-opener"
+      data-style="zoom-in"
+      data-title="Title modal"
+      data-size="md"
+      data-header="true"
+      data-footer="false"
+      data-render="contact-form"
+      data-view="Title"
+      >
+      <span class="ladda-label">Modal</span>
+  </a>
+
+  Options: data-render - contact-form, render, template-part
   */
 
 `;

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -315,6 +315,22 @@ return (
    // some comment
    $test
 );
+
+/***
+ * Configures the tasks tabs (sub_menu)
+ */
+
+class Test {
+  /******************************************
+   * ORIGINAL SHIPPING DATA
+   *****************************************/
+   public $test;
+}
+
+/*
+      some test
+
+  */
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 /** @var int $int This is a counter. */
@@ -374,16 +390,14 @@ class Foo
  *********************/
 
 // This is a one-line c++ style comment
-/**
- * This is a multi line comment
- * yet another line of comment
- */
+/* This is a multi line comment
+ yet another line of comment */
 
-/**
- * This is a multiple-lines comment block
- * that spans over multiple
- * lines
- */
+/*
+This is a multiple-lines comment block
+that spans over multiple
+lines
+*/
 
 # This is a one-line shell-style comment
 
@@ -421,6 +435,23 @@ return (
     // some comment
     $test
 );
+
+/***
+ * Configures the tasks tabs (sub_menu)
+ */
+
+class Test
+{
+    /******************************************
+     * ORIGINAL SHIPPING DATA
+     *****************************************/
+    public $test;
+}
+
+/*
+      some test
+
+  */
 
 `;
 

--- a/tests/comments/comments.php
+++ b/tests/comments/comments.php
@@ -103,3 +103,19 @@ return (
    // some comment
    $test
 );
+
+/***
+ * Configures the tasks tabs (sub_menu)
+ */
+
+class Test {
+  /******************************************
+   * ORIGINAL SHIPPING DATA
+   *****************************************/
+   public $test;
+}
+
+/*
+      some test
+
+  */

--- a/tests/comments/comments.php
+++ b/tests/comments/comments.php
@@ -119,3 +119,21 @@ class Test {
       some test
 
   */
+
+  /*
+  <a href="#"
+      class="btn btn-info ladda-button"
+      data-ui-component="unified-modal-opener"
+      data-style="zoom-in"
+      data-title="Title modal"
+      data-size="md"
+      data-header="true"
+      data-footer="false"
+      data-render="contact-form"
+      data-view="Title"
+      >
+      <span class="ladda-label">Modal</span>
+  </a>
+
+  Options: data-render - contact-form, render, template-part
+  */


### PR DESCRIPTION
fixes #303 fixes #268

Pretty much re-using the same logic from the js printer https://github.com/prettier/prettier/blob/master/src/language-js/printer-estree.js#L5383