### PR TITLE
tests: adding test for crlf docblocks

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -18,6 +18,10 @@ function parse(text) {
   // currently inline comments include the line break at the end, we need to
   // strip those out and update the end location for each comment manually
   ast.comments.forEach(comment => {
+    if (comment.value[comment.value.length - 1] === "\r") {
+      comment.value = comment.value.slice(0, -1);
+      comment.loc.end.offset = comment.loc.end.offset - 1;
+    }
     if (comment.value[comment.value.length - 1] === "\n") {
       comment.value = comment.value.slice(0, -1);
       comment.loc.end.offset = comment.loc.end.offset - 1;

--- a/tests/newline/CRLF.php
+++ b/tests/newline/CRLF.php
@@ -1,2 +1,10 @@
 <?php
 $test = 1;
+
+class Foo
+{
+    /**
+     * Comment indented with tabs in file with utf-8[dos]
+     */
+    private $foo;
+}

--- a/tests/newline/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/newline/__snapshots__/jsfmt.spec.js.snap
@@ -3,9 +3,25 @@
 exports[`CRLF.php 1`] = `
 <?php
 $test = 1;
+
+class Foo
+{
+    /**
+     * Comment indented with tabs in file with utf-8[dos]
+     */
+    private $foo;
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 $test = 1;
+
+class Foo
+{
+    /**
+     * Comment indented with tabs in file with utf-8[dos]
+     */
+    private $foo;
+}
 
 `;
 


### PR DESCRIPTION
just adding test for https://github.com/prettier/plugin-php/issues/262

Also stripping `\r\n` from the parser, according to https://github.com/glayzzle/php-parser/issues/155#issuecomment-384763532