### PR TITLE
Add tests for PHP code blocks in markdown

### DIFF
--- a/tests/embed/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/embed/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test.md 1`] = `
+# PHP in Markdown
+
+\`\`\`php
+<?php
+if($foo) {
+echo "bar";
+}
+\`\`\`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# PHP in Markdown
+
+\`\`\`php
+<?php
+if ($foo) {
+  echo "bar";
+}
+\`\`\`
+
+`;

--- a/tests/embed/jsfmt.spec.js
+++ b/tests/embed/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["markdown"]);

--- a/tests/embed/test.md
+++ b/tests/embed/test.md
@@ -1,0 +1,8 @@
+# PHP in Markdown
+
+```php
+<?php
+if($foo) {
+echo "bar";
+}
+```


### PR DESCRIPTION
While this is working already, there are a few issues:

* code is indented with 2 spaces instead of 4
* the leading `<?php` is required