### PR TITLE
fix: printing comments attached to extends and implements nodes

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -83,8 +83,28 @@ const handleForLoop = comment => {
 };
 
 const handleClass = comment => {
-  const { enclosingNode } = comment;
+  const { enclosingNode, followingNode } = comment;
   if (enclosingNode && enclosingNode.kind === "class") {
+    // for extends nodes that have leading comments, we can store them as
+    // dangling comments so we can handle them in the printer
+    if (followingNode === enclosingNode.extends) {
+      addDanglingComment(followingNode, comment);
+      return true;
+    }
+    // check each implements node - if any of them have comments we can store
+    // them as dangling comments and handle them in the printer
+    if (followingNode && enclosingNode.implements) {
+      if (
+        enclosingNode.implements.some(implementsNode => {
+          if (followingNode && followingNode === implementsNode) {
+            addDanglingComment(followingNode, comment);
+            return true;
+          }
+        })
+      ) {
+        return true;
+      }
+    }
     // for an empty class where the body is only made up of comments, we
     // need to attach this as a dangling comment on the class node itself
     if (!(enclosingNode.body && enclosingNode.body.length > 0)) {

--- a/src/printer.js
+++ b/src/printer.js
@@ -1470,7 +1470,26 @@ function printStatement(path, options, print) {
                 concat([
                   node.extends
                     ? group(
-                        concat([line, "extends ", path.call(print, "extends")])
+                        concat([
+                          // check if the extends node has a comment
+                          hasDanglingComments(node.extends)
+                            ? concat([
+                                hardline,
+                                path.call(
+                                  extendsPath =>
+                                    comments.printDanglingComments(
+                                      extendsPath,
+                                      options,
+                                      true
+                                    ),
+                                  "extends"
+                                ),
+                                hardline
+                              ])
+                            : line,
+                          "extends ",
+                          path.call(print, "extends")
+                        ])
                       )
                     : "",
                   node.implements
@@ -1480,10 +1499,25 @@ function printStatement(path, options, print) {
                         group(
                           indent(
                             concat([
-                              line,
                               join(
-                                concat([",", line]),
-                                path.map(print, "implements")
+                                ",",
+                                path.map(implementsPath => {
+                                  // check if any of the implements nodes have comments
+                                  return hasDanglingComments(
+                                    implementsPath.getValue()
+                                  )
+                                    ? concat([
+                                        hardline,
+                                        comments.printDanglingComments(
+                                          implementsPath,
+                                          options,
+                                          true
+                                        ),
+                                        hardline,
+                                        print(implementsPath)
+                                      ])
+                                    : concat([line, print(implementsPath)]);
+                                }, "implements")
                               )
                             ])
                           )

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -283,6 +283,19 @@ interface Template_Interface {
 class Foo {/* Comment */}
 interface FooI {/* Comment */}
 trait FooT {/* Comment */}
+
+// 424 : Method failure
+class ResponseMethodFailure 
+  // behaves as an error
+  extends ResponseNotAcceptable
+  implements
+    // Some comment
+    FooBar,
+    // Another comment
+    BarBaz
+{
+
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 namespace Test\\test\\test;
@@ -358,6 +371,19 @@ interface FooI
 trait FooT
 {
     /* Comment */
+}
+
+// 424 : Method failure
+class ResponseMethodFailure
+    // behaves as an error
+    extends ResponseNotAcceptable
+    implements
+        // Some comment
+        FooBar,
+        // Another comment
+        BarBaz
+{
+
 }
 
 `;

--- a/tests/comments/class.php
+++ b/tests/comments/class.php
@@ -59,3 +59,16 @@ interface Template_Interface {
 class Foo {/* Comment */}
 interface FooI {/* Comment */}
 trait FooT {/* Comment */}
+
+// 424 : Method failure
+class ResponseMethodFailure 
+  // behaves as an error
+  extends ResponseNotAcceptable
+  implements
+    // Some comment
+    FooBar,
+    // Another comment
+    BarBaz
+{
+
+}


### PR DESCRIPTION
fix: https://github.com/prettier/plugin-php/issues/357