### PR TITLE
fix: print return type declaration for closure

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1987,6 +1987,23 @@ function printStatement(path, options, print) {
               ])
             )
           : "",
+        node.type
+          ? concat([
+              ": ",
+              hasDanglingComments(node.type)
+                ? concat([
+                    path.call(
+                      typePath =>
+                        comments.printDanglingComments(typePath, options, true),
+                      "type"
+                    ),
+                    " "
+                  ])
+                : "",
+              node.nullable ? "?" : "",
+              path.call(print, "type")
+            ])
+          : "",
         " {",
         indent(
           concat([hasEmptyBody ? "" : hardline, path.call(print, "body")])

--- a/tests/closure/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/closure/__snapshots__/jsfmt.spec.js.snap
@@ -66,6 +66,67 @@ $foo->bar(
 $emptyFunc = function(){};
 
 $emptyFuncWithComment = function(){ /* Comment */ };
+
+$longArgs_noVars = function (
+    $longArgument,
+    $longerArgument,
+    $muchLongerArgument
+) {
+    // body
+};
+
+$noArgs_longVars = function () use (
+    $longVar1,
+    $longerVar2,
+    $muchLongerVar3
+) {
+    // body
+};
+
+$longArgs_longVars = function (
+    $longArgument,
+    $longerArgument,
+    $muchLongerArgument
+) use (
+    $longVar1,
+    $longerVar2,
+    $muchLongerVar3
+) {
+    // body
+};
+
+$longArgs_shortVars = function (
+    $longArgument,
+    $longerArgument,
+    $muchLongerArgument
+) use ($var1) {
+    // body
+};
+
+$shortArgs_longVars = function ($arg) use (
+    $longVar1,
+    $longerVar2,
+    $muchLongerVar3
+) {
+    // body
+};
+
+$rTD = function(array $array): int {
+    return array_sum($array);
+};
+
+$rNTD = function(array $array): ?int {
+    return array_sum($array);
+};
+
+$rTDWU = function(array $array) use ($var1, $var2): int {
+    return array_sum($array);
+};
+
+$rTDWLU = function(array $array) use ($longLongLongLongLongLongLongVar1, $longerLongerLongerLongerVar2, $muchLongerVar3): int {
+    return array_sum($array);
+};
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 $closureWithArgs = function ($arg1, $arg2) {
@@ -133,6 +194,62 @@ $emptyFunc = function () {
 
 $emptyFuncWithComment = function () {
     /* Comment */
+};
+
+$longArgs_noVars = function (
+    $longArgument,
+    $longerArgument,
+    $muchLongerArgument
+) {
+    // body
+};
+
+$noArgs_longVars = function () use ($longVar1, $longerVar2, $muchLongerVar3) {
+    // body
+};
+
+$longArgs_longVars = function (
+    $longArgument,
+    $longerArgument,
+    $muchLongerArgument
+) use ($longVar1, $longerVar2, $muchLongerVar3) {
+    // body
+};
+
+$longArgs_shortVars = function (
+    $longArgument,
+    $longerArgument,
+    $muchLongerArgument
+) use ($var1) {
+    // body
+};
+
+$shortArgs_longVars = function ($arg) use (
+    $longVar1,
+    $longerVar2,
+    $muchLongerVar3
+) {
+    // body
+};
+
+$rTD = function (array $array): int {
+    return array_sum($array);
+};
+
+$rNTD = function (array $array): ?int {
+    return array_sum($array);
+};
+
+$rTDWU = function (array $array) use ($var1, $var2): int {
+    return array_sum($array);
+};
+
+$rTDWLU = function (array $array) use (
+    $longLongLongLongLongLongLongVar1,
+    $longerLongerLongerLongerVar2,
+    $muchLongerVar3
+): int {
+    return array_sum($array);
 };
 
 `;

--- a/tests/closure/closure.php
+++ b/tests/closure/closure.php
@@ -63,3 +63,64 @@ $foo->bar(
 $emptyFunc = function(){};
 
 $emptyFuncWithComment = function(){ /* Comment */ };
+
+$longArgs_noVars = function (
+    $longArgument,
+    $longerArgument,
+    $muchLongerArgument
+) {
+    // body
+};
+
+$noArgs_longVars = function () use (
+    $longVar1,
+    $longerVar2,
+    $muchLongerVar3
+) {
+    // body
+};
+
+$longArgs_longVars = function (
+    $longArgument,
+    $longerArgument,
+    $muchLongerArgument
+) use (
+    $longVar1,
+    $longerVar2,
+    $muchLongerVar3
+) {
+    // body
+};
+
+$longArgs_shortVars = function (
+    $longArgument,
+    $longerArgument,
+    $muchLongerArgument
+) use ($var1) {
+    // body
+};
+
+$shortArgs_longVars = function ($arg) use (
+    $longVar1,
+    $longerVar2,
+    $muchLongerVar3
+) {
+    // body
+};
+
+$rTD = function(array $array): int {
+    return array_sum($array);
+};
+
+$rNTD = function(array $array): ?int {
+    return array_sum($array);
+};
+
+$rTDWU = function(array $array) use ($var1, $var2): int {
+    return array_sum($array);
+};
+
+$rTDWLU = function(array $array) use ($longLongLongLongLongLongLongVar1, $longerLongerLongerLongerVar2, $muchLongerVar3): int {
+    return array_sum($array);
+};
+

--- a/tests/functions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/functions/__snapshots__/jsfmt.spec.js.snap
@@ -120,50 +120,6 @@ function the_panel_title(
     return $title;
 }
 
-$longArgs_noVars = function (
-    $longArgument,
-    $longerArgument,
-    $muchLongerArgument
-) {
-    // body
-};
-
-$noArgs_longVars = function () use (
-    $longVar1,
-    $longerVar2,
-    $muchLongerVar3
-) {
-    // body
-};
-
-$longArgs_longVars = function (
-    $longArgument,
-    $longerArgument,
-    $muchLongerArgument
-) use (
-    $longVar1,
-    $longerVar2,
-    $muchLongerVar3
-) {
-    // body
-};
-
-$longArgs_shortVars = function (
-    $longArgument,
-    $longerArgument,
-    $muchLongerArgument
-) use ($var1) {
-    // body
-};
-
-$shortArgs_longVars = function ($arg) use (
-    $longVar1,
-    $longerVar2,
-    $muchLongerVar3
-) {
-    // body
-};
-
 function emptyFunction(){}
 function emptyFunctionWithComment(){ /* Comment */ }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -311,42 +267,6 @@ function the_panel_title(
 
     return $title;
 }
-
-$longArgs_noVars = function (
-    $longArgument,
-    $longerArgument,
-    $muchLongerArgument
-) {
-    // body
-};
-
-$noArgs_longVars = function () use ($longVar1, $longerVar2, $muchLongerVar3) {
-    // body
-};
-
-$longArgs_longVars = function (
-    $longArgument,
-    $longerArgument,
-    $muchLongerArgument
-) use ($longVar1, $longerVar2, $muchLongerVar3) {
-    // body
-};
-
-$longArgs_shortVars = function (
-    $longArgument,
-    $longerArgument,
-    $muchLongerArgument
-) use ($var1) {
-    // body
-};
-
-$shortArgs_longVars = function ($arg) use (
-    $longVar1,
-    $longerVar2,
-    $muchLongerVar3
-) {
-    // body
-};
 
 function emptyFunction()
 {

--- a/tests/functions/functions.php
+++ b/tests/functions/functions.php
@@ -117,49 +117,5 @@ function the_panel_title(
     return $title;
 }
 
-$longArgs_noVars = function (
-    $longArgument,
-    $longerArgument,
-    $muchLongerArgument
-) {
-    // body
-};
-
-$noArgs_longVars = function () use (
-    $longVar1,
-    $longerVar2,
-    $muchLongerVar3
-) {
-    // body
-};
-
-$longArgs_longVars = function (
-    $longArgument,
-    $longerArgument,
-    $muchLongerArgument
-) use (
-    $longVar1,
-    $longerVar2,
-    $muchLongerVar3
-) {
-    // body
-};
-
-$longArgs_shortVars = function (
-    $longArgument,
-    $longerArgument,
-    $muchLongerArgument
-) use ($var1) {
-    // body
-};
-
-$shortArgs_longVars = function ($arg) use (
-    $longVar1,
-    $longerVar2,
-    $muchLongerVar3
-) {
-    // body
-};
-
 function emptyFunction(){}
 function emptyFunctionWithComment(){ /* Comment */ }


### PR DESCRIPTION
Critical bug :smile: 

Also move all `closure` from `function` directory to `closure` directory