### PR TITLE
fix: handle empty lines between comments in ast with children

### DIFF
--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -172,6 +172,27 @@ $bool = /*Comment */ true /*Comment */ || /*Comment */ false; /*Comment */
 
 `;
 
+exports[`blank_lines.php 1`] = `
+<?php
+
+// The first line of a comment
+// The second line of a comment
+
+// A third line which has a blank line before it
+
+
+// Other comment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// The first line of a comment
+// The second line of a comment
+
+// A third line which has a blank line before it
+
+<?php
+// Other comment
+
+`;
+
 exports[`break.php 1`] = `
 <?php
 

--- a/tests/comments/blank_lines.php
+++ b/tests/comments/blank_lines.php
@@ -1,0 +1,9 @@
+<?php
+
+// The first line of a comment
+// The second line of a comment
+
+// A third line which has a blank line before it
+
+
+// Other comment


### PR DESCRIPTION
fixes #368 

Need fix problem with inline (full refactor logic), before we can't solve problems with inline nodes we can't release stable version, I ask for help from everyone who is interested in stable release