### PR TITLE
fix: better print empty declare node

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2047,8 +2047,9 @@ function printStatement(path, options, print) {
           "declare(",
           printDeclareArguments(path),
           "):",
-          hardline,
-          concat(path.map(print, "children")),
+          node.children.length > 0
+            ? concat([hardline, concat(path.map(print, "children"))])
+            : "",
           hardline,
           "enddeclare;"
         ]);
@@ -2057,7 +2058,9 @@ function printStatement(path, options, print) {
           "declare(",
           printDeclareArguments(path),
           ") {",
-          indent(concat([hardline, concat(path.map(print, "children"))])),
+          node.children.length > 0
+            ? indent(concat([hardline, concat(path.map(print, "children"))]))
+            : "",
           hardline,
           "}"
         ]);

--- a/tests/declare/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/declare/__snapshots__/jsfmt.spec.js.snap
@@ -22,6 +22,12 @@ $test = 1;
 if ($var) {
     declare(ticks=1);
 }
+
+declare(ticks=1) {
+}
+
+declare(ticks=1):
+enddeclare;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 declare(ticks=1):
@@ -44,5 +50,11 @@ $test = 1;
 if ($var) {
     declare(ticks=1);
 }
+
+declare(ticks=1) {
+}
+
+declare(ticks=1):
+enddeclare;
 
 `;

--- a/tests/declare/declare.php
+++ b/tests/declare/declare.php
@@ -19,3 +19,9 @@ $test = 1;
 if ($var) {
     declare(ticks=1);
 }
+
+declare(ticks=1) {
+}
+
+declare(ticks=1):
+enddeclare;


### PR DESCRIPTION
Rare use case, but found in our docs :smile:  