### PR TITLE
fix: extra curly around variable

### DIFF
--- a/tests/member_chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/member_chain/__snapshots__/jsfmt.spec.js.snap
@@ -66,7 +66,7 @@ $weNeedToReachTheEightyCharacterLimitXXXXXXXXXXXXXXXXX->someNode
 $superSupersuperSupersuperSupersuperSupersuperSuperLong->exampleOfOrderOfGetterAndSetterReordered;
 $superSupersuperSupersuperSupersuperSupersuperSuperLong
     ->exampleOfOrderOfGetterAndSetterReordered[0];
-$superSupersuperSupersuperSupersuperSupersuperSuperLong->{$exampleOfOrderOfGetterAndSetterReordered};
+$superSupersuperSupersuperSupersuperSupersuperSuperLong->$exampleOfOrderOfGetterAndSetterReordered;
 $superSupersuperSupersuperSupersuperSupersuperSuperLong::$exampleOfOrderOfGetterAndSetterReordered;
 $superSupersuperSupersuperSupersuperSupersuperSuperLong
     ::$exampleOfOrderOfGetterAndSetterReordered[0];

--- a/tests/propertylookup/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/propertylookup/__snapshots__/jsfmt.spec.js.snap
@@ -25,7 +25,7 @@ $a = $obj->value;
 $a = &$obj->getValue();
 $obj->value = 2;
 
-$b = $this->{foo};
+$b = $this->foo;
 $b = $this->{foo['bar']};
 $b = $this->{'foo' . $bar};
 $b = $this->{self::STUFF};

--- a/tests/variable/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/variable/__snapshots__/jsfmt.spec.js.snap
@@ -18,6 +18,38 @@ $_4site = 'not yet';
 $täyte = 'mansikka';
 $bar = &$foo;
 $bar = "My name is $bar";
+$id = $element->{$id_field};
+$id = $element[$id_field];
+$var = <<<EOT
+My name is "$name". I am printing some $foo->foo.
+Now, I am printing some {$foo->bar[1]}.
+This should print a capital 'A': \\x41
+EOT;
+$var = "He drank some $juice juice.".PHP_EOL;
+$var = "He drank some $juices[0] juice.".PHP_EOL;
+$var = "He drank some $juices[koolaid1] juice.".PHP_EOL;
+$var = "$people->john then said hello to $people->jane.".PHP_EOL;
+$var = "{$foo->{$baz[1]}}\\n";
+$var = $var->{$var->property};
+$var = $var->$var->property;
+$var = $var->{'😀'};
+
+// http://php.net/manual/ru/migration70.incompatible.php#migration70.incompatible.variable-handling.indirect
+
+$var = $$foo['bar']['baz'];
+$var = $foo->$bar['baz'];
+$var = $foo->$bar['baz']();
+$var = Foo::$bar['baz']();
+
+$var = \${$foo['bar']['baz']};
+$var = $foo->{$bar['baz']};
+$var = $foo->{$bar['baz']}();
+// $var = Foo::{$bar['baz']}();
+
+$var = ($$foo)['bar']['baz'];
+$var = ($foo->$bar)['baz'];
+$var = ($foo->$bar)['baz']();
+$var = (Foo::$bar)['baz']();
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 $var = 'Bob';
@@ -26,5 +58,38 @@ $_4site = 'not yet';
 $täyte = 'mansikka';
 $bar = &$foo;
 $bar = "My name is $bar";
+$id = $element->$id_field;
+$id = $element[$id_field];
+$var = <<<EOT
+My name is "$name". I am printing some {$foo->foo}.
+Now, I am printing some {$foo
+    ->bar[1]}.
+This should print a capital 'A': \\x41
+EOT;
+$var = "He drank some $juice juice." . PHP_EOL;
+$var = "He drank some {$juices[0]} juice." . PHP_EOL;
+$var = "He drank some {$juices[koolaid1]} juice." . PHP_EOL;
+$var = "{$people->john} then said hello to {$people->jane}." . PHP_EOL;
+$var = "{$foo->{$baz[1]}}\\n";
+$var = $var->{$var->property};
+$var = $var->$var->property;
+$var = $var->{'😀'};
+
+// http://php.net/manual/ru/migration70.incompatible.php#migration70.incompatible.variable-handling.indirect
+
+$var = $$foo['bar']['baz'];
+$var = $foo->$bar['baz'];
+$var = $foo->$bar['baz']();
+$var = Foo::$bar['baz']();
+
+$var = \${$foo['bar']['baz']};
+$var = $foo->{$bar['baz']};
+$var = $foo->{$bar['baz']}();
+// $var = Foo::{$bar['baz']}();
+
+$var = ($$foo)['bar']['baz'];
+$var = ($foo->$bar)['baz'];
+$var = ($foo->$bar)['baz']();
+$var = (Foo::$bar)['baz']();
 
 `;

--- a/tests/variable/variable.php
+++ b/tests/variable/variable.php
@@ -6,3 +6,35 @@ $_4site = 'not yet';
 $täyte = 'mansikka';
 $bar = &$foo;
 $bar = "My name is $bar";
+$id = $element->{$id_field};
+$id = $element[$id_field];
+$var = <<<EOT
+My name is "$name". I am printing some $foo->foo.
+Now, I am printing some {$foo->bar[1]}.
+This should print a capital 'A': \x41
+EOT;
+$var = "He drank some $juice juice.".PHP_EOL;
+$var = "He drank some $juices[0] juice.".PHP_EOL;
+$var = "He drank some $juices[koolaid1] juice.".PHP_EOL;
+$var = "$people->john then said hello to $people->jane.".PHP_EOL;
+$var = "{$foo->{$baz[1]}}\n";
+$var = $var->{$var->property};
+$var = $var->$var->property;
+$var = $var->{'😀'};
+
+// http://php.net/manual/ru/migration70.incompatible.php#migration70.incompatible.variable-handling.indirect
+
+$var = $$foo['bar']['baz'];
+$var = $foo->$bar['baz'];
+$var = $foo->$bar['baz']();
+$var = Foo::$bar['baz']();
+
+$var = ${$foo['bar']['baz']};
+$var = $foo->{$bar['baz']};
+$var = $foo->{$bar['baz']}();
+// $var = Foo::{$bar['baz']}();
+
+$var = ($$foo)['bar']['baz'];
+$var = ($foo->$bar)['baz'];
+$var = ($foo->$bar)['baz']();
+$var = (Foo::$bar)['baz']();


### PR DESCRIPTION
fixes #270 

Note: 
- Fix bug when we break `php5` code (http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.indirect). All values should be printed as is, don't changed.
- Find bug in parser https://github.com/glayzzle/php-parser/issues/167
- Refactor `variable` inside `encapsed` (fast exit, increase perf)