### PR TITLE
fix: better print `closure` in array

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2394,7 +2394,7 @@ function printNode(path, options, print) {
           concat([
             path.call(print, "key"),
             " =>",
-            ["array", "call"].includes(node.value.kind)
+            ["array", "call", "closure"].includes(node.value.kind)
               ? concat([" ", printed])
               : indent(concat([line, printed]))
           ])

--- a/tests/array/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/array/__snapshots__/jsfmt.spec.js.snap
@@ -383,6 +383,17 @@ $arr = [
 ["id" => $id1, "name" => $name1] = $data;
 [["id" => $id1, "name" => $name1]] = $data;
 [["veryVeryVeryVeryLongKey" => $veryVeryVeryVeryLongValue, "veryVeryVeryVeryLongOtherKey" => $veryVeryVeryVeryLongValue]] = $data;
+$arr = [
+    'niveisFederativos' =>
+        function () {
+            return "value";
+        },
+
+    'veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey' =>
+        function () {
+            return "other-value";
+        }
+];
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 $test = array(1, 2, 3, 4, "test");
@@ -517,5 +528,14 @@ $arr = [
         "veryVeryVeryVeryLongOtherKey" => $veryVeryVeryVeryLongValue
     ]
 ] = $data;
+$arr = [
+    'niveisFederativos' => function () {
+        return "value";
+    },
+
+    'veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey' => function () {
+        return "other-value";
+    }
+];
 
 `;

--- a/tests/array/arrays.php
+++ b/tests/array/arrays.php
@@ -380,3 +380,14 @@ $arr = [
 ["id" => $id1, "name" => $name1] = $data;
 [["id" => $id1, "name" => $name1]] = $data;
 [["veryVeryVeryVeryLongKey" => $veryVeryVeryVeryLongValue, "veryVeryVeryVeryLongOtherKey" => $veryVeryVeryVeryLongValue]] = $data;
+$arr = [
+    'niveisFederativos' =>
+        function () {
+            return "value";
+        },
+
+    'veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey' =>
+        function () {
+            return "other-value";
+        }
+];


### PR DESCRIPTION
https://prettier.io/playground/#N4Igxg9gdgLgprEAuEASAbgQwE4AIC8uwAOlLrsSPAM4yb0ONPMutvseuVK4BmArlDAwAltFw0YACgCUJMuVzY4MftjKUAjJQDcpcgF9SBkABoQEAA6jo1ZKBzYIAdwAKOBHZSZ0EEQBMzEAAjbEwwAGsVAGVLcJEoAHNkGGx+OHME6jhsGFcwxIBbTGReTAAbbPMAK2oADwAhMMiYzEK4ABkEuFKKqpA47GzsZBDMYIBPcuggy2wEmAB1AJgAC2QADgAGczmIbMWwy1G5uGH0HvNlAEd+EWV8zCKSpDLKjJBswpEUtI-qBKJcpwACK-Ag8F673MdGCy38a2QABYYWEROVAQBhCCFYqjKDQS4gfjZAAq4y8b2yBgMQA

I started to integrate `prettier` for php in my projects, there is a lot of ugly code, but it is great we do not break it anywhere :star: 

In near future i will fix all ugly code and maybe we ready for a stable release