### PR TITLE
Be more specific about when to not wrap constref nodes in property lookups

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -606,7 +606,16 @@ function printArgumentsList(path, options, print, argumentsKey = "arguments") {
 }
 
 function wrapPropertyLookup(node, doc) {
-  const addCurly = !["variable", "constref"].includes(node.offset.kind);
+  let addCurly = true;
+
+  if (node.offset.kind === "variable") {
+    addCurly = false;
+  } else if (
+    node.offset.kind === "constref" &&
+    typeof node.offset.name === "string"
+  ) {
+    addCurly = false;
+  }
 
   return addCurly ? concat(["{", doc, "}"]) : doc;
 }

--- a/tests/propertylookup/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/propertylookup/__snapshots__/jsfmt.spec.js.snap
@@ -26,7 +26,7 @@ $a = $obj->value;
 $a = &$obj->getValue();
 $obj->value = 2;
 
-$b = $this->foo;
+$b = $this->{foo};
 $b = $this->{foo['bar']};
 $b = $this->{'foo' . $bar};
 $b = $this->{self::STUFF};

--- a/tests/propertylookup/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/propertylookup/__snapshots__/jsfmt.spec.js.snap
@@ -7,6 +7,7 @@ $a = $obj->value;
 $a = &$obj->getValue();
 $obj->value = 2;
 
+$b = $this->foo;
 $b = $this->{foo};
 $b = $this->{foo['bar']};
 $b = $this->{'foo' . $bar};
@@ -26,6 +27,7 @@ $a = $obj->value;
 $a = &$obj->getValue();
 $obj->value = 2;
 
+$b = $this->foo;
 $b = $this->{foo};
 $b = $this->{foo['bar']};
 $b = $this->{'foo' . $bar};

--- a/tests/propertylookup/propertylookup.php
+++ b/tests/propertylookup/propertylookup.php
@@ -4,6 +4,7 @@ $a = $obj->value;
 $a = &$obj->getValue();
 $obj->value = 2;
 
+$b = $this->foo;
 $b = $this->{foo};
 $b = $this->{foo['bar']};
 $b = $this->{'foo' . $bar};


### PR DESCRIPTION
Running the tests with AST comparison brought this to my attention. Removing the curly braces in this context means `foo` is no longer being evaluated as a constant.