### PR TITLE
fix: AST comparison during testing

### DIFF
--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -64,20 +64,23 @@ function run_spec(dirname, parsers, options) {
         const output = prettier.format(source, compareOptions);
 
         let outputAST;
-        let outputASTErr = null;
+        let reoutput;
+        let secondPassErr = null;
         try {
           outputAST = stripLocation(
             prettier.__debug.parse(output, compareOptions, true)
           );
+          reoutput = prettier.format(output, compareOptions);
         } catch (e) {
-          outputASTErr = e.stack;
+          secondPassErr = e.stack;
         }
 
         test(`${path} parse`, () => {
-          expect(outputASTErr).toBe(null);
+          expect(secondPassErr).toBe(null);
           expect(outputAST).toBeDefined();
           if (!originalAST.errors || originalAST.errors.length === 0) {
             expect(outputAST.ast.children).toEqual(originalAST.ast.children);
+            expect(output).toEqual(reoutput);
           }
         });
       }


### PR DESCRIPTION
This is in reference to issue #514.

This code works for me and for what I was trying to test, but I don't know for sure that, for example, `parsers[0] === "php"` is quite the right check, as I'm not very familiar with the internals yet.

How in-depth are pull requests supposed to be? I can add more explanations for the changes if needed!