### PR TITLE
don't use tokens for build new ast for inline

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1,13 +1,9 @@
 "use strict";
 const engine = require("php-parser");
 
-function inBetweenLines(line, node, nextNode) {
-  return (
-    nextNode && node.loc.end.line <= line && nextNode.loc.start.line > line
-  );
-}
-
 function parse(text) {
+  text = text.replace(/\?>\n<\?/g, "?>\n___PSEUDO_INLINE_PLACEHOLDER___<?");
+
   // initialize a new parser instance
   const parser = new engine({
     parser: {
@@ -22,31 +18,6 @@ function parse(text) {
 
   const ast = parser.parseCode(text);
 
-  // parser doesn't create `inline` node between `?>\n<?`, so we add them manually
-  const missingLinebreaks = ast.tokens.filter((token, index, tokens) => {
-    return (
-      token[0] === "T_CLOSE_TAG" &&
-      token[1] === "?>\n" &&
-      tokens[index + 1] &&
-      tokens[index + 1][0] === "T_OPEN_TAG"
-    );
-  });
-  const lines = missingLinebreaks.map(token => token[2]);
-
-  const astIndices = ast.children.reduce((acc, child, index, children) => {
-    if (lines.find(line => inBetweenLines(line, child, children[index + 1]))) {
-      acc.push(index + 1);
-    }
-    return acc;
-  }, []);
-  astIndices.forEach((i, j) => {
-    ast.children.splice(i + j, 0, {
-      kind: "inline",
-      raw: "\n",
-      value: ""
-    });
-  });
-
   // https://github.com/glayzzle/php-parser/issues/155
   // currently inline comments include the line break at the end, we need to
   // strip those out and update the end location for each comment manually
@@ -60,6 +31,7 @@ function parse(text) {
       comment.loc.end.offset = comment.loc.end.offset - 1;
     }
   });
+
   return ast;
 }
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -1066,7 +1066,10 @@ function printExpression(path, options, print) {
             : ""
         ]);
       case "inline":
-        return join(literalline, node.raw.split("\n"));
+        return join(
+          literalline,
+          node.raw.replace("___PSEUDO_INLINE_PLACEHOLDER___", "").split("\n")
+        );
       case "magic":
         // for magic constant we prefer upper case
         return node.value.toUpperCase();

--- a/tests/inline/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/inline/__snapshots__/jsfmt.spec.js.snap
@@ -1321,10 +1321,8 @@ exports[`mixed-32.php 1`] = `
     <?php echo 'test'; ?>
 <div></div>
 <div></div>
-<?php
-if (true);
-echo 'test';
-?>
+<?php if (true); ?>
+<?php echo 'test'; ?>
 <div></div>
 
 `;
@@ -1355,6 +1353,128 @@ exports[`mixed-34.php 1`] = `
     echo 'test';
 } ?>
 <div></div>
+
+`;
+
+exports[`mixed-35.php 1`] = `
+<?php if (!is_ajax()) { ?>
+    <?php do_action('woocommerce_review_order_after_payment'); ?>
+<?php } ?>
+
+<?php if (!is_ajax()) { ?>
+    <?php if (!is_ajax()) { ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php } ?>
+<?php } ?>
+
+<?php if (!is_ajax()) { ?>
+    <?php if (!is_ajax()) { ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php } ?>
+    <?php do_action('woocommerce_review_order_after_payment'); ?>
+<?php } ?>
+
+<?php if (!is_ajax()) { ?>
+    <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php if (!is_ajax()) { ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php } ?>
+<?php } ?>
+
+<?php if (!is_ajax()) { ?>
+    <?php if (!is_ajax()) { ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php } ?>
+    <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php if (!is_ajax()) { ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php } ?>
+<?php } ?>
+
+<?php
+
+function test()
+{
+    ?>
+    <?php if (!is_ajax()) { ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php } ?>
+    <?php
+}
+
+function testTwo()
+{
+    ?>
+    <?php if (!is_ajax()) { ?>
+        <?php if (!is_ajax()) { ?>
+            <?php do_action('woocommerce_review_order_after_payment'); ?>
+        <?php } ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+        <?php if (!is_ajax()) { ?>
+            <?php do_action('woocommerce_review_order_after_payment'); ?>
+        <?php } ?>
+    <?php } ?>
+    <?php
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<?php if (!is_ajax()) { ?>
+    <?php do_action('woocommerce_review_order_after_payment'); ?>
+<?php } ?>
+
+<?php if (!is_ajax()) { ?>
+    <?php if (!is_ajax()) { ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php } ?>
+<?php } ?>
+
+<?php if (!is_ajax()) { ?>
+    <?php if (!is_ajax()) { ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php } ?>
+    <?php do_action('woocommerce_review_order_after_payment'); ?>
+<?php } ?>
+
+<?php if (!is_ajax()) { ?>
+    <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php if (!is_ajax()) { ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php } ?>
+<?php } ?>
+
+<?php if (!is_ajax()) { ?>
+    <?php if (!is_ajax()) { ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php } ?>
+    <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php if (!is_ajax()) { ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php } ?>
+<?php } ?>
+
+<?php
+function test()
+{
+    ?>
+    <?php if (!is_ajax()) { ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php } ?>
+    <?php
+}
+function testTwo()
+{
+    ?>
+    <?php if (!is_ajax()) { ?>
+        <?php if (!is_ajax()) { ?>
+            <?php do_action('woocommerce_review_order_after_payment'); ?>
+        <?php } ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+        <?php if (!is_ajax()) { ?>
+            <?php do_action('woocommerce_review_order_after_payment'); ?>
+        <?php } ?>
+    <?php } ?>
+    <?php
+}
+
 
 `;
 

--- a/tests/inline/mixed-35.php
+++ b/tests/inline/mixed-35.php
@@ -1,0 +1,59 @@
+<?php if (!is_ajax()) { ?>
+    <?php do_action('woocommerce_review_order_after_payment'); ?>
+<?php } ?>
+
+<?php if (!is_ajax()) { ?>
+    <?php if (!is_ajax()) { ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php } ?>
+<?php } ?>
+
+<?php if (!is_ajax()) { ?>
+    <?php if (!is_ajax()) { ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php } ?>
+    <?php do_action('woocommerce_review_order_after_payment'); ?>
+<?php } ?>
+
+<?php if (!is_ajax()) { ?>
+    <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php if (!is_ajax()) { ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php } ?>
+<?php } ?>
+
+<?php if (!is_ajax()) { ?>
+    <?php if (!is_ajax()) { ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php } ?>
+    <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php if (!is_ajax()) { ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php } ?>
+<?php } ?>
+
+<?php
+
+function test()
+{
+    ?>
+    <?php if (!is_ajax()) { ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+    <?php } ?>
+    <?php
+}
+
+function testTwo()
+{
+    ?>
+    <?php if (!is_ajax()) { ?>
+        <?php if (!is_ajax()) { ?>
+            <?php do_action('woocommerce_review_order_after_payment'); ?>
+        <?php } ?>
+        <?php do_action('woocommerce_review_order_after_payment'); ?>
+        <?php if (!is_ajax()) { ?>
+            <?php do_action('woocommerce_review_order_after_payment'); ?>
+        <?php } ?>
+    <?php } ?>
+    <?php
+}


### PR DESCRIPTION
I studied in detail and came to the conclusion that this is the only working solution at the moment, not breaking the code.

Why?
Inline nodes can be in branch of control structures and it is very hard implement. (example inline node can be inside `else if` or `else`). Introduce new ast nodes (or andd based on tokens) is very bad solution (i vote doesn't do this never), many nodes can contain branches like `test`, `esle`, `testExpr`, `arguments` and etc, we will have to run through them - it is a lot of lines of code and a lot of bugs. Better wait fix in parses (or fix it and send PR).