### PR TITLE
fix: extra space in namespace without name

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1215,7 +1215,7 @@ function printNode(path, options, print) {
         "namespace ",
         hasName ? node.name : "",
         node.withBrackets
-          ? " {"
+          ? concat([hasName ? " " : "", "{"])
           : concat([
               ";",
               // Second hardline for newline between `namespace` and first child node

--- a/tests/namespace/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/namespace/__snapshots__/jsfmt.spec.js.snap
@@ -64,7 +64,7 @@ exports[`without-name.php 1`] = `
 namespace {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
-namespace  {
+namespace {
 }
 
 `;


### PR DESCRIPTION
ugly