### PR TITLE
feat: markdown support

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -23,7 +23,13 @@ function parse(text, parsers, opts) {
     }
   });
 
-  const ast = parser.parseCode(text);
+  const hasOpenPHPTag = text.indexOf("<?php") !== -1;
+  const parseAsEval = inMarkdown && !hasOpenPHPTag;
+  const ast = parseAsEval ? parser.parseEval(text) : parser.parseCode(text);
+
+  ast.extra = {
+    parseAsEval
+  };
 
   // Todo https://github.com/glayzzle/php-parser/issues/176
   ast.loc.source = text;

--- a/src/printer.js
+++ b/src/printer.js
@@ -955,7 +955,7 @@ function printLines(path, options, print, childrenAttribute = "children") {
 
   const wrappedParts = wrapPartsIntoGroups(parts, groupIndexes);
 
-  if (node.kind === "program") {
+  if (node.kind === "program" && !node.extra.parseAsEval) {
     if (!wrappedParts.length && node.comments) {
       wrappedParts.push(
         hardline,

--- a/tests/markdown/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`markdown.md 1`] = `
+# PHP in Markdown
+
 \`\`\`php
-$foo = 'bar';
+$foo='bar';
 
 \`\`\`
 
@@ -11,17 +13,152 @@ $foo = 'bar';
 \`\`\`
 
 \`\`\`php
+\`\`\`
+
+\`\`\`php
+function test(){$a=1;}
+\`\`\`
+
+\`\`\`php
+<?php
+if($foo) {
+echo "bar";
+}
+\`\`\`
+
+\`\`\`php
+<?php
+include'./1.php';
+include'./i.php';
+require'./2.php';
+
+$files=get_included_files();
+var_dump(     $files_list     );
+var_dump(     get_required_files(     )     );
+\`\`\`
+
+\`\`\`php
+include'./1.php';
+include'./i.php';
+require'./2.php';
+
+$files=get_included_files(     );
+var_dump(     $files_list     );
+var_dump(     get_required_files(     )     );
+\`\`\`
+
+\`\`\`php
+<?php
+$foo=1;
+?>
+\`\`\`
+
+\`\`\`php
+
+
+
+
+<?php
+$foo=1;
+
+
+
+
+
+\`\`\`
+
+\`\`\`php
+test
+<?php
+$a=1;
+$b=2;
+$c=3;
+?>
+test
+<?php
+echo'foo';
+if(true){echo'test';}
+echo'bar';
+?>
+test
+
 \`\`\`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-\`\`\`php
-$foo = 'bar';
-\`\`\`
+# PHP in Markdown
 
 \`\`\`php
 $foo = 'bar';
 \`\`\`
 
 \`\`\`php
+$foo = 'bar';
+\`\`\`
+
+\`\`\`php
+\`\`\`
+
+\`\`\`php
+function test()
+{
+  $a = 1;
+}
+\`\`\`
+
+\`\`\`php
+<?php
+if ($foo) {
+  echo "bar";
+}
+\`\`\`
+
+\`\`\`php
+<?php
+include './1.php';
+include './i.php';
+require './2.php';
+
+$files = get_included_files();
+var_dump($files_list);
+var_dump(get_required_files());
+\`\`\`
+
+\`\`\`php
+include './1.php';
+include './i.php';
+require './2.php';
+
+$files = get_included_files();
+var_dump($files_list);
+var_dump(get_required_files());
+\`\`\`
+
+\`\`\`php
+<?php
+$foo = 1;
+?>
+\`\`\`
+
+\`\`\`php
+<?php
+$foo = 1;
+\`\`\`
+
+\`\`\`php
+test
+<?php
+$a = 1;
+$b = 2;
+$c = 3;
+?>
+test
+<?php
+echo 'foo';
+if (true) {
+  echo 'test';
+}
+echo 'bar';
+?>
+test
 \`\`\`
 
 `;

--- a/tests/markdown/markdown.md
+++ b/tests/markdown/markdown.md
@@ -1,5 +1,7 @@
+# PHP in Markdown
+
 ```php
-$foo = 'bar';
+$foo='bar';
 
 ```
 
@@ -8,4 +10,73 @@ $foo = 'bar';
 ```
 
 ```php
+```
+
+```php
+function test(){$a=1;}
+```
+
+```php
+<?php
+if($foo) {
+echo "bar";
+}
+```
+
+```php
+<?php
+include'./1.php';
+include'./i.php';
+require'./2.php';
+
+$files=get_included_files();
+var_dump(     $files_list     );
+var_dump(     get_required_files(     )     );
+```
+
+```php
+include'./1.php';
+include'./i.php';
+require'./2.php';
+
+$files=get_included_files(     );
+var_dump(     $files_list     );
+var_dump(     get_required_files(     )     );
+```
+
+```php
+<?php
+$foo=1;
+?>
+```
+
+```php
+
+
+
+
+<?php
+$foo=1;
+
+
+
+
+
+```
+
+```php
+test
+<?php
+$a=1;
+$b=2;
+$c=3;
+?>
+test
+<?php
+echo'foo';
+if(true){echo'test';}
+echo'bar';
+?>
+test
+
 ```


### PR DESCRIPTION
Awesome :star: 

We support:
```php
$a=1;
```

```php
<?php
$a=1;
```

Some people use `<?php`, some not, let's support both