### PR TITLE
fix: add newline after heredoc and nowdoc parameter

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1438,6 +1438,10 @@ function printNode(path, options, print) {
       ]);
 
       if (node.value) {
+        const isHeredocOrNowdocNode =
+          (node.value.kind === "encapsed" && node.value.type === "heredoc") ||
+          node.value.kind === "nowdoc";
+
         return group(
           concat([
             name,
@@ -1446,7 +1450,14 @@ function printNode(path, options, print) {
             // and value, we store them as dangling comments
             hasDanglingComments(node) ? " " : "",
             comments.printDanglingComments(path, options, true),
-            indent(concat([line, "= ", path.call(print, "value")]))
+            indent(
+              concat([
+                isHeredocOrNowdocNode ? " " : line,
+                "= ",
+                path.call(print, "value")
+              ])
+            ),
+            isHeredocOrNowdocNode ? hardline : ""
           ])
         );
       }

--- a/tests/encapsed/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/encapsed/__snapshots__/jsfmt.spec.js.snap
@@ -62,6 +62,29 @@ foo
 EOF
 , "bar"
 );
+
+function foo($a = 1, $b = <<<EOF
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOF
+    , $c = 1
+) {
+    echo $b;
+}
+
+function foo1(
+    $a = 1,
+    $b = <<<EOF
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOF
+    ,
+    $c = 1
+) {
+    echo $b;
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 $encapsShell = \`a $b\`;
@@ -129,6 +152,34 @@ EOF
     ,
     "bar"
 );
+
+function foo(
+    $a = 1,
+    $b = <<<EOF
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOF
+    ,
+    $c = 1
+)
+{
+    echo $b;
+}
+
+function foo1(
+    $a = 1,
+    $b = <<<EOF
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOF
+    ,
+    $c = 1
+)
+{
+    echo $b;
+}
 
 `;
 

--- a/tests/encapsed/encapsed.php
+++ b/tests/encapsed/encapsed.php
@@ -59,3 +59,26 @@ foo
 EOF
 , "bar"
 );
+
+function foo($a = 1, $b = <<<EOF
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOF
+    , $c = 1
+) {
+    echo $b;
+}
+
+function foo1(
+    $a = 1,
+    $b = <<<EOF
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOF
+    ,
+    $c = 1
+) {
+    echo $b;
+}

--- a/tests/nowdoc/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/nowdoc/__snapshots__/jsfmt.spec.js.snap
@@ -39,6 +39,29 @@ $str = sprintf(<<<EOD
 foo
 EOD
 , true);
+
+function foo($a = 1, $b = <<<'EOD'
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOD
+, $c = 1
+) {
+    echo $b;
+}
+
+function foo1(
+    $a = 1,
+    $b = <<<'EOD'
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOD
+    ,
+    $c = 1
+) {
+    echo $b;
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 
@@ -87,6 +110,34 @@ EOD
     ,
     true
 );
+
+function foo(
+    $a = 1,
+    $b = <<<'EOD'
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOD
+    ,
+    $c = 1
+)
+{
+    echo $b;
+}
+
+function foo1(
+    $a = 1,
+    $b = <<<'EOD'
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOD
+    ,
+    $c = 1
+)
+{
+    echo $b;
+}
 
 `;
 

--- a/tests/nowdoc/nowdoc.php
+++ b/tests/nowdoc/nowdoc.php
@@ -36,3 +36,26 @@ $str = sprintf(<<<EOD
 foo
 EOD
 , true);
+
+function foo($a = 1, $b = <<<'EOD'
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOD
+, $c = 1
+) {
+    echo $b;
+}
+
+function foo1(
+    $a = 1,
+    $b = <<<'EOD'
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOD
+    ,
+    $c = 1
+) {
+    echo $b;
+}


### PR DESCRIPTION
big bug, also better print their before `=`