### PR TITLE
fix: broken `retif` without parens

### DIFF
--- a/src/needs-parens.js
+++ b/src/needs-parens.js
@@ -176,7 +176,7 @@ function needsParens(path) {
         case "cast":
           return true;
         case "retif":
-          return name === "test" && parent.test === node;
+          return true;
         case "propertylookup":
         case "staticlookup":
         case "offsetlookup":

--- a/tests/parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/parens/__snapshots__/jsfmt.spec.js.snap
@@ -2285,8 +2285,16 @@ $var = $var . ($var ? "()" : "");
 $var = +($var ? 1 : 2);
 $var = +(+$var ? 1 : 2);
 $var = +($var++ ? 1 : 2);
-$var = (true ? 'true' : false) ? true ? 'true' : false : true ? 'true' : false;
-$var = ($var ? $var1 ? 1 : 2 : $var2) ? 3 : 4;
+$var = (true
+        ? 'true'
+        : false)
+    ? (true
+        ? 'true'
+        : false)
+    : (true
+        ? 'true'
+        : false);
+$var = ($var ? ($var1 ? 1 : 2) : $var2) ? 3 : 4;
 
 `;
 
@@ -2316,7 +2324,7 @@ return (
     'veryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString'
 );
 return $var1 + $var2;
-return $var ? $var1 ? 1 : 2 : $var2 ? 3 : 4;
+return $var ? ($var1 ? 1 : 2) : ($var2 ? 3 : 4);
 return 'veryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString'
     ? 'veryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString'
     : 'veryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString';

--- a/tests/retif/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/retif/__snapshots__/jsfmt.spec.js.snap
@@ -90,26 +90,26 @@ $category_color = get_field(Category_Meta::COLOR, 'category_' . $term_id)
     ?: 'gold';
 
 $var = ($someOtherReallyReallyLongVariable
-        ? $someOtherReallyReallyLongVariable
+        ? ($someOtherReallyReallyLongVariable
             ? $someOtherReallyReallyLongVariable
-            : $someOtherReallyReallyLongVariable
+            : $someOtherReallyReallyLongVariable)
         : $someOtherReallyReallyLongVariable)
     ? $someOtherReallyReallyLongVariable
     : $someOtherReallyReallyLongVariable;
 $var = ($someOtherReallyReallyLongVariable
-        ? $someOtherReallyReallyLongVariable
+        ? ($someOtherReallyReallyLongVariable
             ? $someOtherReallyReallyLongVariable
-            : $someOtherReallyReallyLongVariable
+            : $someOtherReallyReallyLongVariable)
         : $someOtherReallyReallyLongVariable)
     ? $someOtherReallyReallyLongVariable
     : $someOtherReallyReallyLongVariable;
 $var = $someOtherReallyReallyLongVariable
-    ? $someOtherReallyReallyLongVariable
+    ? ($someOtherReallyReallyLongVariable
         ? $someOtherReallyReallyLongVariable
-        : $someOtherReallyReallyLongVariable
-    : $someOtherReallyReallyLongVariable
+        : $someOtherReallyReallyLongVariable)
+    : ($someOtherReallyReallyLongVariable
         ? $someOtherReallyReallyLongVariable
-        : $someOtherReallyReallyLongVariable;
+        : $someOtherReallyReallyLongVariable);
 $test = $foo
     ?: bar(
         $someOtherReallyReallyLongVariable,
@@ -171,28 +171,28 @@ $var = 1
     ? $someOtherReallyReallyLongVariable
     : $someOtherReallyReallyLongVariable
 )->call();
-$var = $test ?: true ? 1 : 2;
+$var = $test ?: (true ? 1 : 2);
 $var = $test
-    ?: $someOtherReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongVariable
+    ?: ($someOtherReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongVariable
         ? 1
-        : 2;
+        : 2);
 $var = $test
-    ?: true
+    ?: (true
         ? $someOtherReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongVariable
-        : 2;
+        : 2);
 $var = $test
-    ?: true
+    ?: (true
         ? 1
-        : $someOtherReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongVariable;
+        : $someOtherReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongVariable);
 $var = $test
     ? 'string'
-    : $someOtherReallyReallyLongVariable
+    : ($someOtherReallyReallyLongVariable
         ? $someOtherReallyReallyLongVariable
-        : $someOtherReallyReallyLongVariable;
+        : $someOtherReallyReallyLongVariable);
 $var = $test
-    ? $someOtherReallyReallyLongVariable
+    ? ($someOtherReallyReallyLongVariable
         ? $someOtherReallyReallyLongVariable
-        : $someOtherReallyReallyLongVariable
+        : $someOtherReallyReallyLongVariable)
     : 'string';
 
 $arr = [


### PR DESCRIPTION
Let's output `parens` for all `nested` `retif`, ternary in `js` is difference than in `php` and it is really difficult to read their without `parens`.

But we can avoid parens for `test` and `trueExpr` properties, but i find this very ugly.

Without `trueExpr`:
```php
true ? 1 ? 2 : 3 : (4 ? 5 : 6); // Inconsistently and ugly
// vs
true ? (1 ? 2 : 3) : (4 ? 5 : 6);
```

Without `test`:
```php
1 ? 2 : 3 ? (1 ? 2 : 3) : (4 ? 5 : 6); // Looks ugly
vs
(1 ? 2 : 3) ? (1 ? 2 : 3) : (4 ? 5 : 6);
```