### PR TITLE
refactor: remove unused stuff

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -197,10 +197,6 @@ const printers = {
           children: { listNodes: ["arguments"], nodes: [] }
         },
         {
-          kinds: ["parenthesis"],
-          children: { listNodes: [], nodes: ["inner"] }
-        },
-        {
           kinds: ["include"],
           children: { listNodes: [], nodes: ["target"] }
         },

--- a/src/util.js
+++ b/src/util.js
@@ -274,10 +274,7 @@ function docShouldHaveTrailingNewline(path) {
 }
 
 function lineShouldEndWithSemicolon(path) {
-  let node = path.getValue();
-  while (node.kind === "parenthesis") {
-    node = node.inner;
-  }
+  const node = path.getValue();
   const parentNode = path.getParentNode();
   if (!parentNode) {
     return false;


### PR DESCRIPTION
Just remove unused `parenthesis` logic