### PR TITLE
refactor: stuff

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -14,8 +14,7 @@ function parse(text, parsers, opts) {
   // initialize a new parser instance
   const parser = new engine({
     parser: {
-      extractDoc: true,
-      extractTokens: true
+      extractDoc: true
     },
     ast: {
       withPositions: true,


### PR DESCRIPTION
reorder print logic for nodes with similar functionality, if somebody know how it can be better PR welcome. Also remove `extractTokens`, it should increase perf. Refactor `continue/break` nodes