### PR TITLE
fix: avoid unnecessary parent around `retif` node without `trueExpr`

### DIFF
--- a/src/needs-parens.js
+++ b/src/needs-parens.js
@@ -179,6 +179,10 @@ function needsParens(path) {
         case "cast":
           return true;
         case "retif":
+          if (name === "test" && !parent.trueExpr) {
+            return false;
+          }
+
           return true;
         case "propertylookup":
         case "staticlookup":

--- a/tests/parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/parens/__snapshots__/jsfmt.spec.js.snap
@@ -2322,6 +2322,14 @@ $var = +(+$var ? 1 : 2);
 $var = +($var++ ? 1 : 2);
 $var = ((true ? 'true' : false) ? (true ? 'true' : false) : (true ? 'true' : false));
 $var = $var ? $var1 ? 1 : 2 : $var2 ? 3 : 4;
+
+$var = $var ?: $var ?: $var ?: 'string';
+$var = ($var ?: $var) ?: $var ?: 'string';
+$var = (($var ?: $var) ?: $var) ?: 'string';
+$var = ((($var ?: $var) ?: $var) ?: 'string');
+$var = ($var ?: ($var ?: $var)) ?: 'string';
+$var = ($var ?: (($var ?: $var) ?: 'string'));
+$var = ($var ?: ($var ?: ($var ?: 'string')));
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 
@@ -2379,6 +2387,14 @@ $var = (true
         ? 'true'
         : false);
 $var = ($var ? ($var1 ? 1 : 2) : $var2) ? 3 : 4;
+
+$var = $var ?: $var ?: $var ?: 'string';
+$var = $var ?: $var ?: $var ?: 'string';
+$var = $var ?: $var ?: $var ?: 'string';
+$var = $var ?: $var ?: $var ?: 'string';
+$var = $var ?: ($var ?: $var) ?: 'string';
+$var = $var ?: ($var ?: $var ?: 'string');
+$var = $var ?: ($var ?: ($var ?: 'string'));
 
 `;
 

--- a/tests/parens/retif.php
+++ b/tests/parens/retif.php
@@ -42,3 +42,11 @@ $var = +(+$var ? 1 : 2);
 $var = +($var++ ? 1 : 2);
 $var = ((true ? 'true' : false) ? (true ? 'true' : false) : (true ? 'true' : false));
 $var = $var ? $var1 ? 1 : 2 : $var2 ? 3 : 4;
+
+$var = $var ?: $var ?: $var ?: 'string';
+$var = ($var ?: $var) ?: $var ?: 'string';
+$var = (($var ?: $var) ?: $var) ?: 'string';
+$var = ((($var ?: $var) ?: $var) ?: 'string');
+$var = ($var ?: ($var ?: $var)) ?: 'string';
+$var = ($var ?: (($var ?: $var) ?: 'string'));
+$var = ($var ?: ($var ?: ($var ?: 'string')));


### PR DESCRIPTION
not same, but good for example https://prettier.io/playground/#N4Igxg9gdgLgprEAuEASAbgQwE4AIC8uGOuA-KUVnuZSTQOQDOM2AllAOb0DcAOlMTyEAFILIVBASnG1qFJi3Zc+AqgVzDRamlJm6GzNpx78xIzWJ1VpVnDfmGl9SSrMbLFLXQnX7uBUbKpmoiHhpecrJ+AU6SLsEkodqeYREyMcZxLiAANCAQAA4wrNCMyKA42BAA7gAKOAhlKJjoEKwAJrkgAEbYmGAA1nAwAMoF-UrILACucHnsjHDYMLV9HAC2mMgAZpgANot5AFaMAB4AQn2DwyOY63AAMuxwO-uHIOPYi9jIPZjdAE89tAugUjDAAOodGAAC2QAA4AAx5MEQRYQvoFX5guDfdAvPLYOAAR2mrCJq0wGy2SF2BzmIEW61YU2wszyjCUezgAEVphB4K96XkYP8oe1YcgAEwivqsPZKADCEHWm1+UGgBJA00WABV-k06YsAL7GoA