### PR TITLE
feat: consistently print assign node with lookup nodes

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1176,7 +1176,7 @@ function isLookupNodeChain(node) {
     return false;
   }
 
-  if (node.what.kind === "variable") {
+  if (["variable", "identifier"].includes(node.what.kind)) {
     return true;
   }
 

--- a/tests/assign/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/assign/__snapshots__/jsfmt.spec.js.snap
@@ -75,6 +75,25 @@ $obj->veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongProperty = $obj->veryVeryV
 $obj->veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongProperty->veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongProperty = (new MyClass())->call($arg);
 $obj->loooooooooooong->lookup = $this->getRequest()->getParam('instance-resource-id');
 $obj->loooooooooooong->lookup = (int) $this->getRequest()->getParam('instance-resource-id');
+
+$component = $var->insertReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component = $var->insertReallyReallyReally{$ReallyReallyReallyReallyReallyLongName};
+$component = Foo::$insertReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component = $a::$insertReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component = (new Foo())->insertReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component = (clone $a)->insertReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+
+$component = $var->insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component = $var->insertReallyReallyReallyReallyReallyReallyReallyReallyReally{$ReallyReallyReallyReallyReallyReallyLongName};
+$component = Foo::$insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component = $a::$insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component = (new Foo())->insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component = (clone $a)->insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+
+$component = $var->insertReallyReallyReallyReallyReallyReallyReallyReallyLongName[0];
+$component = Foo::$insertReallyReallyReallyReallyReallyReallyReallyReallyLongName[0];
+$component = $var->insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName[0];
+$component = Foo::$insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName[0];
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 $var = 1;
@@ -209,5 +228,44 @@ $obj->loooooooooooong->lookup = $this->getRequest()->getParam(
 $obj->loooooooooooong->lookup = (int) $this->getRequest()->getParam(
     'instance-resource-id'
 );
+
+$component =
+    $var->insertReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component =
+    $var->insertReallyReallyReally{$ReallyReallyReallyReallyReallyLongName};
+$component =
+    Foo::$insertReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component =
+    $a::$insertReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component = (new Foo())
+    ->insertReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component = (clone $a)
+    ->insertReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+
+$component =
+    $var->insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component =
+    $var->insertReallyReallyReallyReallyReallyReallyReallyReallyReally{
+        $ReallyReallyReallyReallyReallyReallyLongName
+    };
+$component =
+    Foo::$insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component =
+    $a::$insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component = (new Foo())
+    ->insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component = (clone $a)
+    ->insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+
+$component =
+    $var->insertReallyReallyReallyReallyReallyReallyReallyReallyLongName[0];
+$component =
+    Foo::$insertReallyReallyReallyReallyReallyReallyReallyReallyLongName[0];
+$component =
+    $var
+        ->insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName[0];
+$component =
+    Foo
+        ::$insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName[0];
 
 `;

--- a/tests/assign/assign.php
+++ b/tests/assign/assign.php
@@ -72,3 +72,22 @@ $obj->veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongProperty = $obj->veryVeryV
 $obj->veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongProperty->veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongProperty = (new MyClass())->call($arg);
 $obj->loooooooooooong->lookup = $this->getRequest()->getParam('instance-resource-id');
 $obj->loooooooooooong->lookup = (int) $this->getRequest()->getParam('instance-resource-id');
+
+$component = $var->insertReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component = $var->insertReallyReallyReally{$ReallyReallyReallyReallyReallyLongName};
+$component = Foo::$insertReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component = $a::$insertReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component = (new Foo())->insertReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component = (clone $a)->insertReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+
+$component = $var->insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component = $var->insertReallyReallyReallyReallyReallyReallyReallyReallyReally{$ReallyReallyReallyReallyReallyReallyLongName};
+$component = Foo::$insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component = $a::$insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component = (new Foo())->insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+$component = (clone $a)->insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName;
+
+$component = $var->insertReallyReallyReallyReallyReallyReallyReallyReallyLongName[0];
+$component = Foo::$insertReallyReallyReallyReallyReallyReallyReallyReallyLongName[0];
+$component = $var->insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName[0];
+$component = Foo::$insertReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName[0];

--- a/tests/member_chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/member_chain/__snapshots__/jsfmt.spec.js.snap
@@ -834,8 +834,9 @@ $page = TableRegistry::insertReallyReallyReallyLongName('Pages')
     ::insertReallyReallyReallyLongName();
 
 $page = TableRegistry::insertReallyReallyReallyLongName[0];
-$page = TableRegistry
-    ::insertReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName[0];
+$page =
+    TableRegistry
+        ::insertReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName[0];
 $page = TableRegistry::insertReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName()
     ::insertReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName[0];
 $page = TableRegistry::insertReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName()
@@ -859,7 +860,8 @@ $component = Foo::test([
     'foobar' => 'barfoo',
     'barfoo' => 'foobar'
 ]);
-$component = Foo
-    ::$insertReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName[0];
+$component =
+    Foo
+        ::$insertReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName[0];
 
 `;


### PR DESCRIPTION
Why? Because `::` in js is not same in `php`