### PR TITLE
refactor: print `class`, `interface` and `trait` nodes

### DIFF
--- a/tests/class/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/class/__snapshots__/jsfmt.spec.js.snap
@@ -176,8 +176,10 @@ $instance = new class extends \\Foo implements \\HandleableInterface {
 };
 
 // Parenthesis on the next line
-$instance = new class extends \\Foo
-    implements \\ArrayAccess, \\Countable, \\Serializable
+$instance = new class extends \\Foo implements
+        \\ArrayAccess,
+        \\Countable,
+        \\Serializable
 {
     // Class content
 };


### PR DESCRIPTION
We should separate functions for print `class`/class like nodes (`interface` and `trait`) and function/function like nodes (`closure` and `method`). Will be done in next PR. It is first part.