### PR TITLE
fix: do not break code with `self`, `static` and `parent` identifier

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2457,8 +2457,20 @@ function printNode(path, options, print) {
       ]);
     case "identifier": {
       const parent = path.getParentNode();
+      const normalizedName = node.name.toLowerCase();
 
-      if (parent.kind === "constref" && node.name.toLowerCase() !== "null") {
+      if (
+        (parent.kind === "staticlookup" &&
+          parent.what === node &&
+          ["self", "parent", "static"].includes(normalizedName)) ||
+        (parent.kind === "parameter" &&
+          parent.type === node &&
+          ["self", "parent", "static"].includes(normalizedName))
+      ) {
+        return node.name.toLowerCase();
+      }
+
+      if (parent.kind === "constref" && normalizedName !== "null") {
         return node.name;
       }
 
@@ -2470,7 +2482,6 @@ function printNode(path, options, print) {
         return "callable";
       }
 
-      const lowerCasedName = node.name.toLowerCase();
       const isLowerCase =
         [
           "int",
@@ -2480,12 +2491,10 @@ function printNode(path, options, print) {
           "null",
           "void",
           "iterable",
-          "object",
-          "self",
-          "parent"
-        ].indexOf(lowerCasedName) !== -1;
+          "object"
+        ].indexOf(normalizedName) !== -1;
 
-      return isLowerCase ? lowerCasedName : node.name;
+      return isLowerCase ? normalizedName : node.name;
     }
     case "error":
     default:

--- a/tests/identifier/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/identifier/__snapshots__/jsfmt.spec.js.snap
@@ -43,6 +43,11 @@ class A {
         static::who();
         sTaTic::who();
     }
+
+    public function foo(self $arg) {}
+    public function foo2(sElF $arg) {}
+    public function foo3(parent $arg) {}
+    public function foo4(pArEnT $arg) {}
 }
 
 // Should don't change
@@ -52,6 +57,11 @@ $var = $array[iNt];
 
 $var = $array->{int};
 $var = $array->{iNt};
+
+self();
+sElF();
+parent();
+pArEnT();
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 
@@ -157,6 +167,19 @@ class A
         static::who();
         static::who();
     }
+
+    public function foo(self $arg)
+    {
+    }
+    public function foo2(self $arg)
+    {
+    }
+    public function foo3(parent $arg)
+    {
+    }
+    public function foo4(parent $arg)
+    {
+    }
 }
 
 // Should don't change
@@ -166,5 +189,10 @@ $var = $array[iNt];
 
 $var = $array->{int};
 $var = $array->{iNt};
+
+self();
+sElF();
+parent();
+pArEnT();
 
 `;

--- a/tests/identifier/identifier.php
+++ b/tests/identifier/identifier.php
@@ -40,6 +40,11 @@ class A {
         static::who();
         sTaTic::who();
     }
+
+    public function foo(self $arg) {}
+    public function foo2(sElF $arg) {}
+    public function foo3(parent $arg) {}
+    public function foo4(pArEnT $arg) {}
 }
 
 // Should don't change
@@ -49,3 +54,8 @@ $var = $array[iNt];
 
 $var = $array->{int};
 $var = $array->{iNt};
+
+self();
+sElF();
+parent();
+pArEnT();


### PR DESCRIPTION
Partial #657