### PR TITLE
fix: avoid unnecessary parens in `bin` with `and` or `or`

### DIFF
--- a/src/needs-parens.js
+++ b/src/needs-parens.js
@@ -69,14 +69,9 @@ function needsParens(path) {
           return false;
       }
     case "bin": {
-      // $var = false or true;
-      // The constant false is assigned to $f before the "or" operation occurs
-      // Acts like: (($var = false) or true)
-      if (["and", "xor", "or"].includes(node.type)) {
-        return true;
-      }
-
       switch (parent.kind) {
+        case "assign":
+          return ["and", "xor", "or"].includes(node.type);
         case "pre":
         case "post":
         case "unary":

--- a/tests/parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/parens/__snapshots__/jsfmt.spec.js.snap
@@ -585,6 +585,25 @@ $var = $var % ($var . $var);
 $var = '100' - '100' - '100';
 $var = ('100' - '100') - '100';
 $var = '100' - ('100' - '100');
+
+if (false || true) {};
+if ((false || true)) {};
+if (false or true) {};
+if ((false or true)) {};
+if (true && false) {};
+if ((true && false)) {};
+if (true and false) {};
+if ((true and false)) {};
+
+if (!$foo or $bar == -1) {}
+if ((!$foo or $bar == -1)) {}
+if ((!$foo or $bar) == -1) {}
+if (!$foo or ($bar == -1)) {}
+
+do {} while ($foo and $bar);
+while ($foo or $bar < 10) {}
+for ($foo or $bar;;) {}
+switch ($foo or $bar) {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 
@@ -867,6 +886,41 @@ $var = $var % ($var . $var);
 $var = '100' - '100' - '100';
 $var = '100' - '100' - '100';
 $var = '100' - ('100' - '100');
+
+if (false || true) {
+}
+if (false || true) {
+}
+if (false or true) {
+}
+if (false or true) {
+}
+if (true && false) {
+}
+if (true && false) {
+}
+if (true and false) {
+}
+if (true and false) {
+}
+
+if (!$foo or $bar == -1) {
+}
+if (!$foo or $bar == -1) {
+}
+if ((!$foo or $bar) == -1) {
+}
+if (!$foo or $bar == -1) {
+}
+
+do {
+} while ($foo and $bar);
+while ($foo or $bar < 10) {
+}
+for ($foo or $bar; ; ) {
+}
+switch ($foo or $bar) {
+}
 
 `;
 

--- a/tests/parens/bin.php
+++ b/tests/parens/bin.php
@@ -278,3 +278,22 @@ $var = $var % ($var . $var);
 $var = '100' - '100' - '100';
 $var = ('100' - '100') - '100';
 $var = '100' - ('100' - '100');
+
+if (false || true) {};
+if ((false || true)) {};
+if (false or true) {};
+if ((false or true)) {};
+if (true && false) {};
+if ((true && false)) {};
+if (true and false) {};
+if ((true and false)) {};
+
+if (!$foo or $bar == -1) {}
+if ((!$foo or $bar == -1)) {}
+if ((!$foo or $bar) == -1) {}
+if (!$foo or ($bar == -1)) {}
+
+do {} while ($foo and $bar);
+while ($foo or $bar < 10) {}
+for ($foo or $bar;;) {}
+switch ($foo or $bar) {}


### PR DESCRIPTION
fixes #685