### PR TITLE
fix: trailing comment in `function` and `method` node

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -30,6 +30,14 @@ args:
 function handleOwnLineComment(comment, text, options, ast, isLastComment) {
   const { precedingNode, enclosingNode, followingNode } = comment;
   return (
+    handleLastFunctionArgComments(
+      text,
+      precedingNode,
+      enclosingNode,
+      followingNode,
+      comment,
+      options
+    ) ||
     handleIfStatementComments(
       text,
       precedingNode,
@@ -51,6 +59,14 @@ function handleOwnLineComment(comment, text, options, ast, isLastComment) {
 function handleEndOfLineComment(comment, text, options, ast, isLastComment) {
   const { precedingNode, enclosingNode, followingNode } = comment;
   return (
+    handleLastFunctionArgComments(
+      text,
+      precedingNode,
+      enclosingNode,
+      followingNode,
+      comment,
+      options
+    ) ||
     handleRetifComments(
       enclosingNode,
       precedingNode,
@@ -116,6 +132,34 @@ function addBlockOrNotComment(node, comment) {
   } else {
     addLeadingComment(node, comment);
   }
+}
+
+function handleLastFunctionArgComments(
+  text,
+  precedingNode,
+  enclosingNode,
+  followingNode,
+  comment,
+  options
+) {
+  const nextCharIndex = getNextNonSpaceNonCommentCharacterIndex(
+    text,
+    comment,
+    options
+  );
+  const nextCharacter = text.charAt(nextCharIndex);
+
+  // Real functions
+  if (
+    !precedingNode &&
+    enclosingNode &&
+    (enclosingNode.kind === "function" || enclosingNode.kind === "method") &&
+    nextCharacter === ")"
+  ) {
+    addTrailingComment(enclosingNode, comment);
+    return true;
+  }
+  return false;
 }
 
 function handleIfStatementComments(

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1533,6 +1533,11 @@ function foo(/* 1 */ $a /* 2 */ = /* 3 */ 1 /* 4 */) {}
 function foo($a): /* 5 */ ?string /* 6 */ {}
 function foo(/* 1 */ $a /* 2 */ = /* 3 */ 1 /* 4 */): /* 5 */ ?string /* 6 */ {}
 function emptyFn(/*Comment */) {}
+function fn( // Comment
+) {}
+function fn(
+    // Comment
+) {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 
@@ -1548,6 +1553,13 @@ function foo(/* 1 */ $a /* 2 */ = /* 3 */ 1 /* 4 */): /* 5 */ ?string /* 6 */
 function emptyFn(/*Comment */)
 {
 }
+function fn()
+{
+} // Comment
+function fn()
+{
+}
+// Comment
 
 `;
 
@@ -2290,6 +2302,20 @@ class Foo {
     abstract public function sortByName(/* bool $useNaturalSort = false */);
 
     /* comment */ protected /* comment */ static /* comment */ $foo /* comment */;
+
+    public function foo( // Comment
+    ) {}
+
+    public function foo(
+        // Comment
+    ) {}
+
+    abstract public function foo( // Comment
+    );
+
+    abstract public function foo(
+        // Comment
+    );
 }
 
 
@@ -2324,6 +2350,20 @@ class Foo
     abstract public function sortByName(/* bool $useNaturalSort = false */); /* comment */
 
     /* comment */ /* comment */ protected static $foo; /* comment */
+
+    public function foo()
+    {
+    } // Comment
+
+    public function foo()
+    {
+    }
+    // Comment
+
+    abstract public function foo(); // Comment
+
+    abstract public function foo();
+    // Comment
 }
 
 class add_vendor extends request

--- a/tests/comments/functions.php
+++ b/tests/comments/functions.php
@@ -4,3 +4,8 @@ function foo(/* 1 */ $a /* 2 */ = /* 3 */ 1 /* 4 */) {}
 function foo($a): /* 5 */ ?string /* 6 */ {}
 function foo(/* 1 */ $a /* 2 */ = /* 3 */ 1 /* 4 */): /* 5 */ ?string /* 6 */ {}
 function emptyFn(/*Comment */) {}
+function fn( // Comment
+) {}
+function fn(
+    // Comment
+) {}

--- a/tests/comments/method.php
+++ b/tests/comments/method.php
@@ -8,6 +8,20 @@ class Foo {
     abstract public function sortByName(/* bool $useNaturalSort = false */);
 
     /* comment */ protected /* comment */ static /* comment */ $foo /* comment */;
+
+    public function foo( // Comment
+    ) {}
+
+    public function foo(
+        // Comment
+    ) {}
+
+    abstract public function foo( // Comment
+    );
+
+    abstract public function foo(
+        // Comment
+    );
 }
 
 


### PR DESCRIPTION
Before we got Error about what we don't print comment