### PR TITLE
fix: indent for `print` node with end of line comment

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2065,7 +2065,12 @@ function printNode(path, options, print) {
       );
     }
     case "print": {
-      return concat(["print ", path.call(print, "arguments")]);
+      return concat([
+        "print ",
+        node.arguments.comments
+          ? indent(path.call(print, "arguments"))
+          : path.call(print, "arguments")
+      ]);
     }
     case "return": {
       const parts = [];

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -2507,14 +2507,45 @@ print // Comment
     ;
 
 print /* Comment */ $foo /* Comment */;
+
+print // Comment
+    $a;
+
+print (// Comment
+    $a
+);
+
+print call(
+    // Comment
+    $a
+);
+
+print // Comment
+    // Comment
+    $a;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 
 print // Comment
-$foo;
-/* Comment */
+    $foo;
+    /* Comment */
 
 print /* Comment */ $foo /* Comment */;
+
+print // Comment
+    $a;
+
+print // Comment
+    $a;
+
+print call(
+    // Comment
+    $a
+);
+
+print // Comment
+    // Comment
+    $a;
 
 `;
 

--- a/tests/comments/print.php
+++ b/tests/comments/print.php
@@ -6,3 +6,19 @@ print // Comment
     ;
 
 print /* Comment */ $foo /* Comment */;
+
+print // Comment
+    $a;
+
+print (// Comment
+    $a
+);
+
+print call(
+    // Comment
+    $a
+);
+
+print // Comment
+    // Comment
+    $a;


### PR DESCRIPTION
Looks we forget about this problem :smile: 