### PR TITLE
feat: print comment for `return` on same line

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -67,6 +67,14 @@ function handleEndOfLineComment(comment, text, options, ast, isLastComment) {
       comment,
       options
     ) ||
+    handleReturnComments(
+      text,
+      precedingNode,
+      enclosingNode,
+      followingNode,
+      comment,
+      options
+    ) ||
     handleLastFunctionArgComments(
       text,
       precedingNode,
@@ -155,6 +163,21 @@ function handleArrayComments(
     enclosingNode &&
     enclosingNode.kind === "array"
   ) {
+    addTrailingComment(enclosingNode, comment);
+    return true;
+  }
+
+  return false;
+}
+
+function handleReturnComments(
+  text,
+  precedingNode,
+  enclosingNode,
+  followingNode,
+  comment
+) {
+  if (enclosingNode && enclosingNode.kind === "return" && !enclosingNode.expr) {
     addTrailingComment(enclosingNode, comment);
     return true;
   }
@@ -632,17 +655,6 @@ function printComments(comments, options) {
   return concat(parts);
 }
 
-// This recurses the return argument, looking for the first token
-// (the leftmost leaf node) and, if it (or its parents) has any
-// leadingComments, returns true (so it can be wrapped in parens).
-function returnArgumentHasLeadingComment(options, argument) {
-  if (hasLeadingOwnLineComment(options.originalText, argument, options)) {
-    return true;
-  }
-
-  return false;
-}
-
 function isBlockComment(comment) {
   return comment.kind === "commentblock";
 }
@@ -656,6 +668,5 @@ module.exports = {
   hasLeadingComment,
   hasTrailingComment,
   hasLeadingOwnLineComment,
-  printComments,
-  returnArgumentHasLeadingComment
+  printComments
 };

--- a/src/printer.js
+++ b/src/printer.js
@@ -2092,11 +2092,7 @@ function printNode(path, options, print) {
       if (node.expr) {
         const printedExpr = path.call(print, "expr");
 
-        if (comments.returnArgumentHasLeadingComment(options, node.expr)) {
-          parts.push(indent(concat([hardline, printedExpr])));
-        } else {
-          parts.push(" ", printedExpr);
-        }
+        parts.push(" ", node.expr.comments ? indent(printedExpr) : printedExpr);
       }
 
       if (hasDanglingComments(node)) {

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1189,8 +1189,7 @@ $constraint = new UniqueEntity(array(
     // no "em" option set
 ));
 
-return
-    // parens test
+return // parens test
     // some comment
     $test;
 
@@ -2838,6 +2837,28 @@ exports[`return.php - php-verify: return.php 1`] = `
 function f() {
     return /* a */;
 }
+
+return // Comment
+    ;
+
+return // Comment
+    $a;
+
+return // Comment
+    [
+        $a, $b, $c
+    ];
+
+return /* Comment */
+    $a;
+
+// Comment
+return $a;
+
+return /* Comment */ $a /* Comment */ = /* Comment */ $b /* Comment */;
+
+return // Comment
+    new Foo();
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 
@@ -2845,6 +2866,25 @@ function f()
 {
     return /* a */;
 }
+
+return; // Comment
+
+return // Comment
+    $a;
+
+return // Comment
+    [$a, $b, $c];
+
+return /* Comment */
+    $a;
+
+// Comment
+return $a;
+
+return /* Comment */ $a /* Comment */ = /* Comment */ $b /* Comment */;
+
+return // Comment
+    new Foo();
 
 `;
 

--- a/tests/comments/return.php
+++ b/tests/comments/return.php
@@ -3,3 +3,25 @@
 function f() {
     return /* a */;
 }
+
+return // Comment
+    ;
+
+return // Comment
+    $a;
+
+return // Comment
+    [
+        $a, $b, $c
+    ];
+
+return /* Comment */
+    $a;
+
+// Comment
+return $a;
+
+return /* Comment */ $a /* Comment */ = /* Comment */ $b /* Comment */;
+
+return // Comment
+    new Foo();


### PR DESCRIPTION
fixes #764

Let's print `return` with comment(s) consistently, as we print other keywords with comment(s)