### PR TITLE
feat: better print if comments

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -272,6 +272,15 @@ function handleIfStatementComments(
     return true;
   }
 
+  // Comments before `else`/`else if` treat as a dangling comment
+  if (
+    precedingNode === enclosingNode.body &&
+    followingNode === enclosingNode.alternate
+  ) {
+    addDanglingComment(enclosingNode, comment);
+    return true;
+  }
+
   if (followingNode.kind === "if") {
     addBlockOrNotComment(followingNode.body, comment);
     return true;
@@ -523,7 +532,6 @@ function handleCommentInEmptyParens(text, enclosingNode, comment, options) {
     (enclosingNode.kind === "function" ||
       enclosingNode.kind === "closure" ||
       enclosingNode.kind === "method" ||
-      enclosingNode.kind === "closure" ||
       enclosingNode.kind === "call" ||
       enclosingNode.kind === "new") &&
     enclosingNode.arguments.length === 0

--- a/src/printer.js
+++ b/src/printer.js
@@ -1312,7 +1312,6 @@ function printBodyControlStructure(
     node.shortForm ? ":" : " {",
     indent(
       concat([
-        comments.printDanglingComments(path, options, true),
         node[bodyProperty].kind !== "block" ||
         (node[bodyProperty].children &&
           node[bodyProperty].children.length > 0) ||
@@ -1668,6 +1667,8 @@ function printNode(path, options, print) {
               comment => comment.trailing && !comments.isBlockComment(comment)
             )) ||
           needsHardlineAfterDanglingComment(node);
+        const elseOnSameLine = !commentOnOwnLine;
+        parts.push(elseOnSameLine ? "" : hardline);
 
         if (hasDanglingComments(node)) {
           parts.push(

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -2119,6 +2119,46 @@ else if (false) // Comment
     echo 'bar';
 else // Comment
     echo 'baz';
+
+// If the values implements the Arrayable interface we can just call this
+// toArray method on the instances which will convert both models and
+// collections to their proper array form and we'll set the values.
+if ($value instanceof Arrayable) {
+    $relation = $value->toArray();
+}
+// If the value is null, we'll still go ahead and set it in this list of
+// attributes since null is used to represent empty relationships if
+// if it a has one or belongs to type relationships on the models.
+elseif (is_null($value)) {
+    $relation = $value;
+}
+
+if (true) {
+    echo 'test';
+} /* comment */ else if (false) {
+    echo 'test';
+}
+// comment
+else {
+    echo 'test';
+}
+
+if (true) echo 'test';
+// comment
+else echo 'test';
+
+if ($code === 92 /* '\\' */) {}
+if ($code === 92 /* '\\' */ /* '\\' */) {}
+
+if ($code === 92) /* '\\' */ {}
+if ($code === 92) { /* '\\' */ }
+
+if (
+1
+    // Comment
+) {
+    $a;
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 // Comment 1
@@ -2127,14 +2167,16 @@ if (1) {
     // Comment 3
     echo "Foo"; // Comment 4
     // Comment 5
-} elseif (2) {
-    // Comment 6
+}
+// Comment 6
+elseif (2) {
     // Comment 7
     // Comment 8
     echo "Bar";
     // Comment 9
-} else {
-    // Comment 10
+}
+// Comment 10
+else {
     // Comment 11
     // Comment 12
     echo "FooBar";
@@ -2153,29 +2195,33 @@ if (2 /* MB_OVERLOAD_STRING */ & (int) ini_get('mbstring.func_overload')) {
 // this is a comment on an if
 if (false) {
     do_nothing();
-} elseif (false) {
-    // and this is a comment on an elseif
+}
+// and this is a comment on an elseif
+elseif (false) {
     also_do_nothing();
 }
 
 if (1) {
     // comment
     false;
-} elseif (2) {
-    // comment
+}
+// comment
+elseif (2) {
     true;
-} elseif (3) {
-    // multi
-    // ple
-    // lines
+}
+// multi
+// ple
+// lines
+elseif (3) {
     // existing comment
     true;
-} elseif (4) {
-    // okay?
+}
+// okay?
+elseif (4) {
     // empty with existing comment
-} else {
-    // comment
-
+}
+// comment
+else {
 }
 
 if (5) {
@@ -2189,8 +2235,9 @@ if (6) {
 } elseif (7) {
     // comment
     true;
-} else {
-    // comment
+}
+// comment
+else {
     true;
 }
 
@@ -2202,9 +2249,10 @@ if (8) {
     // comment
     // comment
     true;
-} else {
-    // comment
-    // comment
+}
+// comment
+// comment
+else {
     true;
 }
 
@@ -2220,8 +2268,7 @@ if (10) {
 } elseif (13) {
     /* comment */ /* comment */ // comment
     true;
-} else {
-    /* comment */
+} /* comment */ else {
     true;
 }
 
@@ -2239,17 +2286,19 @@ if (14) {
 
 if ($cond) {
     stuff();
-} elseif ($cond) {
-    /* comment */ stuff();
-} else {
-    // comment
+} /* comment */ elseif ($cond) {
+    stuff();
+}
+// comment
+else {
     stuff();
 }
 
 if ($cond) {
     stuff();
-} else {
-    // comment
+}
+// comment
+else {
     stuff();
 }
 
@@ -2323,8 +2372,9 @@ if (true) {
 } elseif (false) {
     // Comment
     echo 'bar';
-} else {
-    // Comment
+}
+// Comment
+else {
     echo 'baz';
 }
 
@@ -2333,9 +2383,61 @@ if (true) {
     echo 'foo';
 } elseif (false) {
     // Comment
-    echo 'bar'; // Comment
-} else {
+    echo 'bar';
+}
+// Comment
+else {
     echo 'baz';
+}
+
+// If the values implements the Arrayable interface we can just call this
+// toArray method on the instances which will convert both models and
+// collections to their proper array form and we'll set the values.
+if ($value instanceof Arrayable) {
+    $relation = $value->toArray();
+}
+// If the value is null, we'll still go ahead and set it in this list of
+// attributes since null is used to represent empty relationships if
+// if it a has one or belongs to type relationships on the models.
+elseif (is_null($value)) {
+    $relation = $value;
+}
+
+if (true) {
+    echo 'test';
+} /* comment */ elseif (false) {
+    echo 'test';
+}
+// comment
+else {
+    echo 'test';
+}
+
+if (true) {
+    echo 'test';
+}
+// comment
+else {
+    echo 'test';
+}
+
+if ($code === 92 /* '\\' */) {
+}
+if ($code === 92 /* '\\' */ /* '\\' */) {
+}
+
+if ($code === 92) {
+    /* '\\' */
+}
+if ($code === 92) {
+    /* '\\' */
+}
+
+if (
+    1
+    // Comment
+) {
+    $a;
 }
 
 `;

--- a/tests/comments/if.php
+++ b/tests/comments/if.php
@@ -183,3 +183,43 @@ else if (false) // Comment
     echo 'bar';
 else // Comment
     echo 'baz';
+
+// If the values implements the Arrayable interface we can just call this
+// toArray method on the instances which will convert both models and
+// collections to their proper array form and we'll set the values.
+if ($value instanceof Arrayable) {
+    $relation = $value->toArray();
+}
+// If the value is null, we'll still go ahead and set it in this list of
+// attributes since null is used to represent empty relationships if
+// if it a has one or belongs to type relationships on the models.
+elseif (is_null($value)) {
+    $relation = $value;
+}
+
+if (true) {
+    echo 'test';
+} /* comment */ else if (false) {
+    echo 'test';
+}
+// comment
+else {
+    echo 'test';
+}
+
+if (true) echo 'test';
+// comment
+else echo 'test';
+
+if ($code === 92 /* '\' */) {}
+if ($code === 92 /* '\' */ /* '\' */) {}
+
+if ($code === 92) /* '\' */ {}
+if ($code === 92) { /* '\' */ }
+
+if (
+1
+    // Comment
+) {
+    $a;
+}


### PR DESCRIPTION
Format comment as prettier for `if/else`, support comments between `if` and `elseif`, `elseif`  and `else`. Also i found this in `laravel` and `symfony`