### PR TITLE
fix: consistent break assign for static lookup

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1383,7 +1383,11 @@ function isLookupNodeChain(node) {
     return false;
   }
 
-  if (["variable", "identifier"].includes(node.what.kind)) {
+  if (
+    ["variable", "identifier"].includes(node.what.kind) ||
+    // TODO: https://github.com/glayzzle/php-parser/issues/183
+    (node.what.kind === "constref" && node.what.name.toLowerCase() === "static")
+  ) {
     return true;
   }
 

--- a/tests/staticlookup/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/staticlookup/__snapshots__/jsfmt.spec.js.snap
@@ -102,6 +102,10 @@ $obj::$veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryV
 $var = ($this->modelClass)::where('name', 'like', strtoupper("%\${key}%"))->get();
 
 MyVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongClass::class;
+
+$var = static::$arrayCache[$arrayStub->class][$arrayStub->position][$arrayStub->foo][$arrayStub->baz];
+$var = self::$arrayCache[$arrayStub->class][$arrayStub->position][$arrayStub->foo][$arrayStub->baz];
+$var = parent::$arrayCache[$arrayStub->class][$arrayStub->position][$arrayStub->foo][$arrayStub->baz];
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 Foo::aStaticMethod();
@@ -202,5 +206,21 @@ $obj::$veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryV
 $var = $this->modelClass::where('name', 'like', strtoupper("%\${key}%"))->get();
 
 MyVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongClass::class;
+
+$var =
+    static
+        ::$arrayCache[$arrayStub->class][$arrayStub->position][$arrayStub->foo][
+            $arrayStub->baz
+        ];
+$var =
+    self
+        ::$arrayCache[$arrayStub->class][$arrayStub->position][$arrayStub->foo][
+            $arrayStub->baz
+        ];
+$var =
+    parent
+        ::$arrayCache[$arrayStub->class][$arrayStub->position][$arrayStub->foo][
+            $arrayStub->baz
+        ];
 
 `;

--- a/tests/staticlookup/staticlookup.php
+++ b/tests/staticlookup/staticlookup.php
@@ -81,3 +81,7 @@ $obj::$veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryV
 $var = ($this->modelClass)::where('name', 'like', strtoupper("%${key}%"))->get();
 
 MyVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongClass::class;
+
+$var = static::$arrayCache[$arrayStub->class][$arrayStub->position][$arrayStub->foo][$arrayStub->baz];
+$var = self::$arrayCache[$arrayStub->class][$arrayStub->position][$arrayStub->foo][$arrayStub->baz];
+$var = parent::$arrayCache[$arrayStub->class][$arrayStub->position][$arrayStub->foo][$arrayStub->baz];


### PR DESCRIPTION
Add todo, when parser fix it we can remove this line