### PR TITLE
refactor: anonymous class

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,41 +33,7 @@ const languages = [
   }
 ];
 
-// for anonymous classes, we need to keep track of the parent "new" node.
-// this is because in a case like this:
-//   $test = new class($arg1, $arg2) extends TestClass {};
-// we actually want to pretend that the class node starts after the "new"
-// node's arguments, since there is logic in prettier that assumes child nodes
-// will never overlap each other (ie the "new" node has the arguments, and class
-// as children, and we can't have them overlap)
-const anonymousClassesNewNodes = [];
 const loc = prop => node => {
-  if (
-    node.kind === "new" &&
-    node.what.kind === "class" &&
-    node.what.isAnonymous &&
-    node.arguments.length > 0 &&
-    !anonymousClassesNewNodes.includes(node)
-  ) {
-    anonymousClassesNewNodes.push(node);
-  }
-  if (prop === "start" && node.kind === "class" && node.isAnonymous) {
-    const parentNewNode = anonymousClassesNewNodes.find(
-      newNode => newNode.what === node
-    );
-    if (parentNewNode && parentNewNode.arguments.length > 0) {
-      const lastArgumentNode =
-        parentNewNode.arguments[parentNewNode.arguments.length - 1];
-      // if this is an anonymous class node with a parent "new" node, use the
-      // location of the last argument in the new node as the fake start location
-      // for this class node
-      return (
-        (lastArgumentNode.loc &&
-          lastArgumentNode.loc.end &&
-          lastArgumentNode.loc.end.offset) + 1
-      );
-    }
-  }
   return node.loc && node.loc[prop] && node.loc[prop].offset;
 };
 

--- a/src/util.js
+++ b/src/util.js
@@ -302,13 +302,6 @@ function lineShouldEndWithSemicolon(path) {
   ) {
     return true;
   }
-  if (
-    parentNode.kind === "class" &&
-    parentNode.isAnonymous &&
-    parentNode.arguments.includes(node)
-  ) {
-    return false;
-  }
   if (!nodeHasStatement(parentNode)) {
     return false;
   }

--- a/tests/class/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/class/__snapshots__/jsfmt.spec.js.snap
@@ -438,9 +438,7 @@ $class = new class(
     function () {
         return 1;
     }
-)
-{
-};
+) {};
 
 $class = new class(
     $arg,
@@ -451,9 +449,7 @@ $class = new class(
     function () {
         return 1;
     }
-) implements MyOtherClass
-{
-};
+) implements MyOtherClass {};
 
 $class = new class(
     $arg,
@@ -464,9 +460,7 @@ $class = new class(
     function () {
         return 1;
     }
-) implements MyOtherClass, MyOtherClass1, MyOtherClass2
-{
-};
+) implements MyOtherClass, MyOtherClass1, MyOtherClass2 {};
 
 $class = new class(
     $arg,
@@ -508,9 +502,7 @@ $class = new class(
     function () {
         return 1;
     }
-) extends MyOtherClass
-{
-};
+) extends MyOtherClass {};
 
 $class = new class(
     $arg,
@@ -535,9 +527,7 @@ $class = new class(
     function () {
         return 1;
     }
-) extends MyOtherClass implements MyI
-{
-};
+) extends MyOtherClass implements MyI {};
 
 $class = new class(
     $arg,
@@ -548,9 +538,7 @@ $class = new class(
     function () {
         return 1;
     }
-) extends MyOtherClass implements MyI, MyII, MyIII
-{
-};
+) extends MyOtherClass implements MyI, MyII, MyIII {};
 
 $class = new class(
     $arg,

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -4770,11 +4770,331 @@ $a = new Foo(/*Comment*/);
 $a = new Foo(/* Comment */ 1 /*Comments*/);
 $a = new // Comment
     Foo();
+
+$a = new // Comment
+    class {};
+
+$a = new class // Comment
+{};
+
+$a = new class // Comment
+($a, $b, $c)
+{};
+
+$a = new class
+(
+    // Comemnt
+    $a,
+    // Comment
+    $b,
+    // Comment
+    $c
+) {};
+
+$a = new class() // Comment
+{};
+
+$a = new class() { // Comment
+};
+
+$a = new class() {
+    // Comment
+};
+
+$a = new class() {
+    // {{{ properties
+
+    /**
+     * The status of foo's universe
+     *
+     * Potential values are 'good', 'fair', 'poor' and 'unknown'.
+     *
+     * @var string
+     */
+    var $foo = 'unknown';
+
+    /**
+     * The status of life
+     *
+     * Note that names of private properties or methods must be
+     * preceeded by an underscore.
+     *
+     * @var bool
+     * @access private
+     */
+    var $_good = true;
+
+    // }}}
+    // {{{ setFoo()
+
+    /**
+     * Registers the status of foo's universe
+     *
+     * Summaries for methods should use 3rd person declarative rather
+     * than 2nd person imperative, beginning with a verb phrase.
+     *
+     * Summaries should add description beyond the method's name. The
+     * best method names are "self-documenting", meaning they tell you
+     * basically what the method does.  If the summary merely repeats
+     * the method name in sentence form, it is not providing more
+     * information.
+     *
+     * Summary Examples:
+     *   + Sets the label              (preferred)
+     *   + Set the label               (avoid)
+     *   + This method sets the label  (avoid)
+     *
+     * Below are the tags commonly used for methods.  A @param tag is
+     * required for each parameter the method has.  The @return
+     * and @access tags are mandatory.  The @throws tag is required if
+     * the method uses exceptions.  @static is required if the method can
+     * be called statically.  The remainder should only be used when
+     * necessary.  Please use them in the order they appear here.
+     * phpDocumentor has several other tags available, feel free to use
+     * them.
+     *
+     * The @param tag contains the data type, then the parameter's
+     * name, followed by a description.  By convention, the first noun in
+     * the description is the data type of the parameter.  Articles like
+     * "a", "an", and  "the" can precede the noun.  The descriptions
+     * should start with a phrase.  If further description is necessary,
+     * follow with sentences.  Having two spaces between the name and the
+     * description aids readability.
+     *
+     * When writing a phrase, do not capitalize and do not end with a
+     * period:
+     *   + the string to be tested
+     *
+     * When writing a phrase followed by a sentence, do not capitalize the
+     * phrase, but end it with a period to distinguish it from the start
+     * of the next sentence:
+     *   + the string to be tested. Must use UTF-8 encoding.
+     *
+     * Return tags should contain the data type then a description of
+     * the data returned.  The data type can be any of PHP's data types
+     * (int, float, bool, string, array, object, resource, mixed)
+     * and should contain the type primarily returned.  For example, if
+     * a method returns an object when things work correctly but false
+     * when an error happens, say 'object' rather than 'mixed.'  Use
+     * 'void' if nothing is returned.
+     *
+     * Here's an example of how to format examples:
+     * <code>
+     * require_once 'Net/Sample.php';
+     *
+     * $s = new Net_Sample();
+     * if (PEAR::isError($s)) {
+     *     echo $s->getMessage() . "\\n";
+     * }
+     * </code>
+     *
+     * Here is an example for non-php example or sample:
+     * <samp>
+     * pear install net_sample
+     * </samp>
+     *
+     * @param string $arg1 the string to quote
+     * @param int    $arg2 an integer of how many problems happened.
+     *                     Indent to the description's starting point
+     *                     for long ones.
+     *
+     * @return int the integer of the set mode used. FALSE if foo
+     *             foo could not be set.
+     * @throws exceptionclass [description]
+     *
+     * @access public
+     * @static
+     * @see Net_Sample::$foo, Net_Other::someMethod()
+     * @since Method available since Release 1.2.0
+     * @deprecated Method deprecated in Release 2.0.0
+     */
+    function setFoo($arg1, $arg2 = 0)
+    {
+        /*
+         * This is a "Block Comment."  The format is the same as
+         * Docblock Comments except there is only one asterisk at the
+         * top.  phpDocumentor doesn't parse these.
+         */
+        if ($arg1 == 'good' || $arg1 == 'fair') {
+            $this->foo = $arg1;
+            return 1;
+        } elseif ($arg1 == 'poor' && $arg2 > 1) {
+            $this->foo = 'poor';
+            return 2;
+        } else {
+            return false;
+        }
+    }
+
+    // }}}
+};
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 $a = new Foo(/*Comment*/);
 $a = new Foo(/* Comment */ 1 /*Comments*/);
 $a = new Foo(); // Comment
+
+$a = new class {}; // Comment
+
+$a = new class {
+    // Comment
+};
+
+$a = new class(
+    // Comment
+    $a,
+    $b,
+    $c
+) {};
+
+$a = new class(
+    // Comemnt
+    $a,
+    // Comment
+    $b,
+    // Comment
+    $c
+) {};
+
+$a = new class {
+    // Comment
+};
+
+$a = new class {
+    // Comment
+};
+
+$a = new class {
+    // Comment
+};
+
+$a = new class {
+    // {{{ properties
+
+    /**
+     * The status of foo's universe
+     *
+     * Potential values are 'good', 'fair', 'poor' and 'unknown'.
+     *
+     * @var string
+     */
+    var $foo = 'unknown';
+
+    /**
+     * The status of life
+     *
+     * Note that names of private properties or methods must be
+     * preceeded by an underscore.
+     *
+     * @var bool
+     * @access private
+     */
+    var $_good = true;
+
+    // }}}
+    // {{{ setFoo()
+
+    /**
+     * Registers the status of foo's universe
+     *
+     * Summaries for methods should use 3rd person declarative rather
+     * than 2nd person imperative, beginning with a verb phrase.
+     *
+     * Summaries should add description beyond the method's name. The
+     * best method names are "self-documenting", meaning they tell you
+     * basically what the method does.  If the summary merely repeats
+     * the method name in sentence form, it is not providing more
+     * information.
+     *
+     * Summary Examples:
+     *   + Sets the label              (preferred)
+     *   + Set the label               (avoid)
+     *   + This method sets the label  (avoid)
+     *
+     * Below are the tags commonly used for methods.  A @param tag is
+     * required for each parameter the method has.  The @return
+     * and @access tags are mandatory.  The @throws tag is required if
+     * the method uses exceptions.  @static is required if the method can
+     * be called statically.  The remainder should only be used when
+     * necessary.  Please use them in the order they appear here.
+     * phpDocumentor has several other tags available, feel free to use
+     * them.
+     *
+     * The @param tag contains the data type, then the parameter's
+     * name, followed by a description.  By convention, the first noun in
+     * the description is the data type of the parameter.  Articles like
+     * "a", "an", and  "the" can precede the noun.  The descriptions
+     * should start with a phrase.  If further description is necessary,
+     * follow with sentences.  Having two spaces between the name and the
+     * description aids readability.
+     *
+     * When writing a phrase, do not capitalize and do not end with a
+     * period:
+     *   + the string to be tested
+     *
+     * When writing a phrase followed by a sentence, do not capitalize the
+     * phrase, but end it with a period to distinguish it from the start
+     * of the next sentence:
+     *   + the string to be tested. Must use UTF-8 encoding.
+     *
+     * Return tags should contain the data type then a description of
+     * the data returned.  The data type can be any of PHP's data types
+     * (int, float, bool, string, array, object, resource, mixed)
+     * and should contain the type primarily returned.  For example, if
+     * a method returns an object when things work correctly but false
+     * when an error happens, say 'object' rather than 'mixed.'  Use
+     * 'void' if nothing is returned.
+     *
+     * Here's an example of how to format examples:
+     * <code>
+     * require_once 'Net/Sample.php';
+     *
+     * $s = new Net_Sample();
+     * if (PEAR::isError($s)) {
+     *     echo $s->getMessage() . "\\n";
+     * }
+     * </code>
+     *
+     * Here is an example for non-php example or sample:
+     * <samp>
+     * pear install net_sample
+     * </samp>
+     *
+     * @param string $arg1 the string to quote
+     * @param int    $arg2 an integer of how many problems happened.
+     *                     Indent to the description's starting point
+     *                     for long ones.
+     *
+     * @return int the integer of the set mode used. FALSE if foo
+     *             foo could not be set.
+     * @throws exceptionclass [description]
+     *
+     * @access public
+     * @static
+     * @see Net_Sample::$foo, Net_Other::someMethod()
+     * @since Method available since Release 1.2.0
+     * @deprecated Method deprecated in Release 2.0.0
+     */
+    function setFoo($arg1, $arg2 = 0)
+    {
+        /*
+         * This is a "Block Comment."  The format is the same as
+         * Docblock Comments except there is only one asterisk at the
+         * top.  phpDocumentor doesn't parse these.
+         */
+        if ($arg1 == 'good' || $arg1 == 'fair') {
+            $this->foo = $arg1;
+            return 1;
+        } elseif ($arg1 == 'poor' && $arg2 > 1) {
+            $this->foo = 'poor';
+            return 2;
+        } else {
+            return false;
+        }
+    }
+
+    // }}}
+};
 
 `;
 

--- a/tests/comments/new.php
+++ b/tests/comments/new.php
@@ -3,3 +3,161 @@ $a = new Foo(/*Comment*/);
 $a = new Foo(/* Comment */ 1 /*Comments*/);
 $a = new // Comment
     Foo();
+
+$a = new // Comment
+    class {};
+
+$a = new class // Comment
+{};
+
+$a = new class // Comment
+($a, $b, $c)
+{};
+
+$a = new class
+(
+    // Comemnt
+    $a,
+    // Comment
+    $b,
+    // Comment
+    $c
+) {};
+
+$a = new class() // Comment
+{};
+
+$a = new class() { // Comment
+};
+
+$a = new class() {
+    // Comment
+};
+
+$a = new class() {
+    // {{{ properties
+
+    /**
+     * The status of foo's universe
+     *
+     * Potential values are 'good', 'fair', 'poor' and 'unknown'.
+     *
+     * @var string
+     */
+    var $foo = 'unknown';
+
+    /**
+     * The status of life
+     *
+     * Note that names of private properties or methods must be
+     * preceeded by an underscore.
+     *
+     * @var bool
+     * @access private
+     */
+    var $_good = true;
+
+    // }}}
+    // {{{ setFoo()
+
+    /**
+     * Registers the status of foo's universe
+     *
+     * Summaries for methods should use 3rd person declarative rather
+     * than 2nd person imperative, beginning with a verb phrase.
+     *
+     * Summaries should add description beyond the method's name. The
+     * best method names are "self-documenting", meaning they tell you
+     * basically what the method does.  If the summary merely repeats
+     * the method name in sentence form, it is not providing more
+     * information.
+     *
+     * Summary Examples:
+     *   + Sets the label              (preferred)
+     *   + Set the label               (avoid)
+     *   + This method sets the label  (avoid)
+     *
+     * Below are the tags commonly used for methods.  A @param tag is
+     * required for each parameter the method has.  The @return
+     * and @access tags are mandatory.  The @throws tag is required if
+     * the method uses exceptions.  @static is required if the method can
+     * be called statically.  The remainder should only be used when
+     * necessary.  Please use them in the order they appear here.
+     * phpDocumentor has several other tags available, feel free to use
+     * them.
+     *
+     * The @param tag contains the data type, then the parameter's
+     * name, followed by a description.  By convention, the first noun in
+     * the description is the data type of the parameter.  Articles like
+     * "a", "an", and  "the" can precede the noun.  The descriptions
+     * should start with a phrase.  If further description is necessary,
+     * follow with sentences.  Having two spaces between the name and the
+     * description aids readability.
+     *
+     * When writing a phrase, do not capitalize and do not end with a
+     * period:
+     *   + the string to be tested
+     *
+     * When writing a phrase followed by a sentence, do not capitalize the
+     * phrase, but end it with a period to distinguish it from the start
+     * of the next sentence:
+     *   + the string to be tested. Must use UTF-8 encoding.
+     *
+     * Return tags should contain the data type then a description of
+     * the data returned.  The data type can be any of PHP's data types
+     * (int, float, bool, string, array, object, resource, mixed)
+     * and should contain the type primarily returned.  For example, if
+     * a method returns an object when things work correctly but false
+     * when an error happens, say 'object' rather than 'mixed.'  Use
+     * 'void' if nothing is returned.
+     *
+     * Here's an example of how to format examples:
+     * <code>
+     * require_once 'Net/Sample.php';
+     *
+     * $s = new Net_Sample();
+     * if (PEAR::isError($s)) {
+     *     echo $s->getMessage() . "\n";
+     * }
+     * </code>
+     *
+     * Here is an example for non-php example or sample:
+     * <samp>
+     * pear install net_sample
+     * </samp>
+     *
+     * @param string $arg1 the string to quote
+     * @param int    $arg2 an integer of how many problems happened.
+     *                     Indent to the description's starting point
+     *                     for long ones.
+     *
+     * @return int the integer of the set mode used. FALSE if foo
+     *             foo could not be set.
+     * @throws exceptionclass [description]
+     *
+     * @access public
+     * @static
+     * @see Net_Sample::$foo, Net_Other::someMethod()
+     * @since Method available since Release 1.2.0
+     * @deprecated Method deprecated in Release 2.0.0
+     */
+    function setFoo($arg1, $arg2 = 0)
+    {
+        /*
+         * This is a "Block Comment."  The format is the same as
+         * Docblock Comments except there is only one asterisk at the
+         * top.  phpDocumentor doesn't parse these.
+         */
+        if ($arg1 == 'good' || $arg1 == 'fair') {
+            $this->foo = $arg1;
+            return 1;
+        } elseif ($arg1 == 'poor' && $arg2 > 1) {
+            $this->foo = 'poor';
+            return 2;
+        } else {
+            return false;
+        }
+    }
+
+    // }}}
+};

--- a/tests/declare/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/declare/__snapshots__/jsfmt.spec.js.snap
@@ -59,6 +59,74 @@ enddeclare;
 
 `;
 
+exports[`declare-invalid.php - php-verify: declare-invalid.php 1`] = `
+<?php
+
+declare(unknown=1);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<?php
+
+declare(unknown=1);
+
+`;
+
+exports[`declare-multiple-statements.php - php-verify: declare-multiple-statements.php 1`] = `
+<?php
+
+declare(ticks=1) {
+    $a = 1;
+    $b = 2;
+}
+
+declare(ticks=2) {
+    function test() {
+        $a = 1;
+    }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<?php
+
+declare(ticks=1) {
+    $a = 1;
+    $b = 2;
+}
+
+declare(ticks=2) {
+    function test()
+    {
+        $a = 1;
+    }
+}
+
+`;
+
+exports[`declare-multiple-statements-2.php - php-verify: declare-multiple-statements-2.php 1`] = `
+<?php
+
+declare(strict_types=1);
+
+$a = 1;
+$b = 2;
+
+function test() {
+    $a = 1;
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<?php
+
+declare(strict_types=1);
+
+$a = 1;
+$b = 2;
+
+function test()
+{
+    $a = 1;
+}
+
+`;
+
 exports[`declare-newline-after.php - php-verify: declare-newline-after.php 1`] = `
 <?php
 declare(ticks=1);

--- a/tests/declare/declare-invalid.php
+++ b/tests/declare/declare-invalid.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(unknown=1);

--- a/tests/declare/declare-multiple-statements-2.php
+++ b/tests/declare/declare-multiple-statements-2.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+$a = 1;
+$b = 2;
+
+function test() {
+    $a = 1;
+}
+

--- a/tests/declare/declare-multiple-statements.php
+++ b/tests/declare/declare-multiple-statements.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(ticks=1) {
+    $a = 1;
+    $b = 2;
+}
+
+declare(ticks=2) {
+    function test() {
+        $a = 1;
+    }
+}

--- a/tests/new/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/new/__snapshots__/jsfmt.spec.js.snap
@@ -169,6 +169,27 @@ string
 string
 $var\`
 );
+
+$var = new class('string
+string
+string') {};
+
+$var = new class(
+    'string
+string
+string'
+) {};
+
+$var = new class(10) extends SomeClass implements SomeInterface {
+    private $num;
+
+    public function __construct($num)
+    {
+        $this->num = $num;
+    }
+
+    use SomeTrait;
+};
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 new Foo();
@@ -301,8 +322,7 @@ $var = new class(
     function () {
         return 1;
     }
-) extends SomeClass implements SomeInterface
-{
+) extends SomeClass implements SomeInterface {
     public function log($msg)
     {
         echo $msg;
@@ -373,5 +393,28 @@ string
 string
 $var\`
 );
+
+$var = new class(
+    'string
+string
+string'
+) {};
+
+$var = new class(
+    'string
+string
+string'
+) {};
+
+$var = new class(10) extends SomeClass implements SomeInterface {
+    private $num;
+
+    public function __construct($num)
+    {
+        $this->num = $num;
+    }
+
+    use SomeTrait;
+};
 
 `;

--- a/tests/new/new.php
+++ b/tests/new/new.php
@@ -166,3 +166,24 @@ string
 string
 $var`
 );
+
+$var = new class('string
+string
+string') {};
+
+$var = new class(
+    'string
+string
+string'
+) {};
+
+$var = new class(10) extends SomeClass implements SomeInterface {
+    private $num;
+
+    public function __construct($num)
+    {
+        $this->num = $num;
+    }
+
+    use SomeTrait;
+};


### PR DESCRIPTION
Also add more tests. 

Why i change output for anonymous class? Because it is looks really ugly in real use case.

Example.
Now:
```php
public static function createLogger($arg) {
    $logger = new class(
        $arg['type'],
        $arg['severity'],
        $arg['filter'], 
        $arg['bail'] 
    ) extends BaseLogger {};

   $logger->init();
   
   return $logger;
}
```

Before:
```php
public static function createLogger($arg) {
    $logger = new class(
        $arg['type'],
        $arg['severity'],
        $arg['filter'], 
        $arg['bail'] 
    ) extends BaseLogger {
    };

   $logger->init();
   
   return $logger;
}
```

Before example have ugly `{` and `}`, there is no reason to add newline after `{`. 