### PR TITLE
fix: avoid parens for `assign` in control structure

### DIFF
--- a/src/needs-parens.js
+++ b/src/needs-parens.js
@@ -33,14 +33,6 @@ function needsParens(path) {
     return false;
   }
 
-  // Avoid parens in short control structures like `if (expr) statement`
-  if (
-    ["if", "while", "for", "foreach"].includes(parent.kind) &&
-    (parent.body === node || parent.alternate === node)
-  ) {
-    return false;
-  }
-
   switch (node.kind) {
     case "pre":
     case "post":
@@ -174,11 +166,13 @@ function needsParens(path) {
         (parent.init.includes(node) || parent.increment.includes(node))
       ) {
         return false;
-      } else if (parent.kind === "while" && node.left.kind === "list") {
-        return false;
       } else if (parent.kind === "assign") {
         return false;
       } else if (parent.kind === "static") {
+        return false;
+      } else if (
+        ["if", "do", "while", "foreach", "switch"].includes(parent.kind)
+      ) {
         return false;
       }
 

--- a/tests/parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/parens/__snapshots__/jsfmt.spec.js.snap
@@ -216,12 +216,12 @@ for ($i = 1; $i <= 10; $i++) {
 }
 for ($i = 1, $j = 0; $i <= 10; $j += $i, print $i, $i++);
 
-if (($a = 1)) {
+if ($a = 1) {
 }
 
-while (($var = 1)) {
+while ($var = 1) {
 }
-while (($var = current($array) !== false)) {
+while ($var = current($array) !== false) {
 }
 while (($var = current($array)) !== false) {
 }
@@ -262,7 +262,7 @@ while ($i <= 10) {
 
 do {
     echo $i;
-} while (($i = 0));
+} while ($i = 0);
 
 for ($i = 1; $i <= 10; $i++) {
     $i = 1;
@@ -278,7 +278,7 @@ foreach ($arr as &$value) {
     $value = $value * 2;
 }
 
-switch (($i = 1)) {
+switch ($i = 1) {
     case 0:
         echo "i equals 0";
         break;
@@ -290,7 +290,7 @@ switch (($i = 1)) {
         break;
 }
 
-switch (($i = 1)) {
+switch ($i = 1) {
     case 0:
         echo "i equals 0";
         break;
@@ -1531,12 +1531,21 @@ while ($i++ < 5) {
 }
 
 if ($var = 1) {}
+if (($var = 1)) {}
+if ($var = 1) {} else if ($var = 1) {} else {}
+if (($var = 1)) {} else if (($var = 1)) {} else {}
 do {} while ($var = 1);
+do {} while (($var = 1));
 while ($var = 1) {}
+while (($var = 1)) {}
+for ($i = 1; $i <= 10; $i++) {}
 for (($i = 1); ($i <= 10); ($i++)) {}
+foreach (($arr = [1, 2, 3]) as $value) {}
 foreach (($arr) as $value) {}
 foreach (($arr) as $key => $value) {}
+foreach (($arr = [1, 2, 3]) as $key => $value) {}
 switch ($var = 1) {}
+switch (($var = 1)) {}
 
 while (list($id, $name, $salary) = $result->fetch(PDO::FETCH_NUM)) {}
 while ([$id, $name, $salary] = $result->fetch(PDO::FETCH_NUM)) {}
@@ -1610,19 +1619,41 @@ while ($i++ < 5) {
     echo "Neither does this.<br />\\n";
 }
 
-if (($var = 1)) {
+if ($var = 1) {
+}
+if ($var = 1) {
+}
+if ($var = 1) {
+} elseif ($var = 1) {
+} else {
+}
+if ($var = 1) {
+} elseif ($var = 1) {
+} else {
 }
 do {
-} while (($var = 1));
-while (($var = 1)) {
+} while ($var = 1);
+do {
+} while ($var = 1);
+while ($var = 1) {
+}
+while ($var = 1) {
 }
 for ($i = 1; $i <= 10; $i++) {
+}
+for ($i = 1; $i <= 10; $i++) {
+}
+foreach ($arr = [1, 2, 3] as $value) {
 }
 foreach ($arr as $value) {
 }
 foreach ($arr as $key => $value) {
 }
-switch (($var = 1)) {
+foreach ($arr = [1, 2, 3] as $key => $value) {
+}
+switch ($var = 1) {
+}
+switch ($var = 1) {
 }
 
 while (list($id, $name, $salary) = $result->fetch(PDO::FETCH_NUM)) {

--- a/tests/parens/control-structures.php
+++ b/tests/parens/control-structures.php
@@ -68,12 +68,21 @@ while ($i++ < 5) {
 }
 
 if ($var = 1) {}
+if (($var = 1)) {}
+if ($var = 1) {} else if ($var = 1) {} else {}
+if (($var = 1)) {} else if (($var = 1)) {} else {}
 do {} while ($var = 1);
+do {} while (($var = 1));
 while ($var = 1) {}
+while (($var = 1)) {}
+for ($i = 1; $i <= 10; $i++) {}
 for (($i = 1); ($i <= 10); ($i++)) {}
+foreach (($arr = [1, 2, 3]) as $value) {}
 foreach (($arr) as $value) {}
 foreach (($arr) as $key => $value) {}
+foreach (($arr = [1, 2, 3]) as $key => $value) {}
 switch ($var = 1) {}
+switch (($var = 1)) {}
 
 while (list($id, $name, $salary) = $result->fetch(PDO::FETCH_NUM)) {}
 while ([$id, $name, $salary] = $result->fetch(PDO::FETCH_NUM)) {}


### PR DESCRIPTION
fixes #731 

Prettier to `js` add parens for assign in control structure, but i think it is good for js, but not for php. Why?
- Popular PHP packages avoid parens (`laravel`, `symfony`, `WordPress` and etc)
- Many built-in `PHP` function return `false`/`null` and many developers using (to avoid extra code):
```php
$file = null;

if ($file = file_get_contents($var)) {
}
```
With parens it is look very ugly