### PR TITLE
fix: avoid semicolon for declare and inline

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -54,7 +54,8 @@ const {
   shouldPrintHardlineBeforeTrailingComma,
   isDocNode,
   getAncestorNode,
-  isReferenceLikeNode
+  isReferenceLikeNode,
+  getNextNode
 } = require("./util");
 
 function shouldPrintComma(options) {
@@ -1485,7 +1486,14 @@ function printNode(path, options, print) {
         ]);
       }
 
-      return concat(["declare(", printDeclareArguments(path), ");"]);
+      const nextNode = getNextNode(path, node);
+
+      return concat([
+        "declare(",
+        printDeclareArguments(path),
+        ")",
+        nextNode && nextNode.kind === "inline" ? "" : ";"
+      ]);
     }
     case "declaredirective":
       return concat([path.call(print, "key"), "=", path.call(print, "value")]);

--- a/src/util.js
+++ b/src/util.js
@@ -531,6 +531,23 @@ function getLastNestedChildNode(node) {
   return node;
 }
 
+function getNextNode(path, node) {
+  const parent = path.getParentNode();
+  const children = getNodeListProperty(parent);
+
+  if (!children) {
+    return null;
+  }
+
+  const index = children.indexOf(node);
+
+  if (index === -1) {
+    return null;
+  }
+
+  return parent.children[index + 1];
+}
+
 function isProgramLikeNode(node) {
   return ["program", "declare", "namespace"].includes(node.kind);
 }
@@ -760,5 +777,6 @@ module.exports = {
   isNextLineEmptyAfterNamespace,
   shouldPrintHardlineBeforeTrailingComma,
   isDocNode,
-  getAncestorNode
+  getAncestorNode,
+  getNextNode
 };

--- a/tests/inline/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/inline/__snapshots__/jsfmt.spec.js.snap
@@ -10,7 +10,26 @@ exports[`declare.php - php-verify: declare.php 1`] = `
     </body>
 </html>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-<?php declare(strict_types=1); ?>
+<?php declare(strict_types=1) ?>
+<html>
+    <body>
+        <?php $a = 1; ?>
+    </body>
+</html>
+
+`;
+
+exports[`declare-1.php - php-verify: declare-1.php 1`] = `
+<?php declare(strict_types=1) ?>
+<html>
+    <body>
+        <?php
+          $a = 1;
+        ?>
+    </body>
+</html>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<?php declare(strict_types=1) ?>
 <html>
     <body>
         <?php $a = 1; ?>

--- a/tests/inline/declare-1.php
+++ b/tests/inline/declare-1.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1) ?>
+<html>
+    <body>
+        <?php
+          $a = 1;
+        ?>
+    </body>
+</html>


### PR DESCRIPTION
From https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md

Example:
```php
<?php declare(strict_types=1) ?>
<html>
<body>
    <?php
        // ... additional PHP code ...
    ?>
</body>
</html>
```