### PR TITLE
fix: add curly when offset is magic node in staticlookup

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -113,7 +113,15 @@ function printPropertyLookup(path, options, print) {
 }
 
 function printStaticLookup(path, options, print) {
-  return concat(["::", path.call(print, "offset")]);
+  const node = path.getValue();
+  const needCurly = node.offset.kind === "magic";
+
+  return concat([
+    "::",
+    needCurly ? "{" : "",
+    path.call(print, "offset"),
+    needCurly ? "}" : ""
+  ]);
 }
 
 function printOffsetLookup(path, options, print) {

--- a/tests/magic/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/magic/__snapshots__/jsfmt.spec.js.snap
@@ -12,6 +12,21 @@ __METHOD__;
 __NAMESPACE__;
 
 $magic = __LINE__;
+
+class Foo extends Base
+{
+    public static function label()
+    {
+        // Here we run \`Base::label\`
+        return __(parent::{__FUNCTION__}());
+    }
+
+    public static function oLabel()
+    {
+        // Here we run \`Base::__FUNCTION__\`
+        return __(parent::__FUNCTION__());
+    }
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 __LINE__;
@@ -24,6 +39,21 @@ __METHOD__;
 __NAMESPACE__;
 
 $magic = __LINE__;
+
+class Foo extends Base
+{
+    public static function label()
+    {
+        // Here we run \`Base::label\`
+        return __(parent::{__FUNCTION__}());
+    }
+
+    public static function oLabel()
+    {
+        // Here we run \`Base::__FUNCTION__\`
+        return __(parent::__FUNCTION__());
+    }
+}
 
 `;
 

--- a/tests/magic/magic.php
+++ b/tests/magic/magic.php
@@ -9,3 +9,18 @@ __METHOD__;
 __NAMESPACE__;
 
 $magic = __LINE__;
+
+class Foo extends Base
+{
+    public static function label()
+    {
+        // Here we run `Base::label`
+        return __(parent::{__FUNCTION__}());
+    }
+
+    public static function oLabel()
+    {
+        // Here we run `Base::__FUNCTION__`
+        return __(parent::__FUNCTION__());
+    }
+}


### PR DESCRIPTION
fixes #858