### PR TITLE
refactor: remove outdated todo from tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prettier": "^1.15.3"
   },
   "peerDependencies": {
-    "prettier": "^1.12.0"
+    "prettier": "^1.15.0"
   },
   "scripts": {
     "test": "jest",

--- a/src/comments.js
+++ b/src/comments.js
@@ -7,7 +7,9 @@ const {
   getNextNonSpaceNonCommentCharacterIndex,
   isNextLineEmpty,
   skipNewline,
-  isPreviousLineEmpty
+  isPreviousLineEmpty,
+  hasNewline,
+  hasNewlineInRange
 } = require("prettier").util;
 const {
   concat,
@@ -18,8 +20,8 @@ const {
   lineSuffix,
   breakParent
 } = require("prettier").doc.builders;
-// TODO: remove after resolve https://github.com/prettier/prettier/pull/5049
-const { hasNewline, hasNewlineInRange, isLookupNode } = require("./util");
+const { isLookupNode } = require("./util");
+
 /*
 Comment functions are meant to inspect various edge cases using given comment nodes,
 with information about where those comment nodes exist in the tree (ie enclosingNode,


### PR DESCRIPTION
Some bugs still exists in parser around `cast` and `silent` node