### PR TITLE
test: comment in lookup

### DIFF
--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -554,6 +554,16 @@ $var = $var
     ->first() // Comment
     // Comment
     ->dump();
+
+$var = $a /* Comment*/->/*Comment*/ bar;
+$var = $a/* Comment */['test'];
+$var = $a /* Comment */->/* Comment */ bar();
+$var = $a /* Comment */::/* Comment */ bar();
+
+$a /* Comment*/./*Comment*/ bar/* Comment */;
+$a/* Comment */['test'];
+$a /* Comment */./* Comment */ bar();
+$a /* Comment */::/* Comment */ bar();
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 
@@ -566,6 +576,17 @@ $var = $var
     ->first() // Comment
     // Comment
     ->dump();
+
+$var = $a /* Comment*/->/*Comment*/ bar;
+$var = /* Comment */ $a['test'];
+$var = $a /* Comment */
+    ->/* Comment */ bar();
+$var = /* Comment */ $a::/* Comment */ bar();
+
+$a /* Comment*/ . /*Comment*/ bar /* Comment */;
+/* Comment */ $a['test'];
+$a /* Comment */ . /* Comment */ bar();
+/* Comment */ $a::/* Comment */ bar();
 
 `;
 

--- a/tests/comments/chains.php
+++ b/tests/comments/chains.php
@@ -9,3 +9,13 @@ $var = $var
     ->first() // Comment
     // Comment
     ->dump();
+
+$var = $a /* Comment*/->/*Comment*/ bar;
+$var = $a/* Comment */['test'];
+$var = $a /* Comment */->/* Comment */ bar();
+$var = $a /* Comment */::/* Comment */ bar();
+
+$a /* Comment*/./*Comment*/ bar/* Comment */;
+$a/* Comment */['test'];
+$a /* Comment */./* Comment */ bar();
+$a /* Comment */::/* Comment */ bar();


### PR DESCRIPTION
Some comment for `offsetlookup` and `staticlookup` have invalid position, but it is already have the PR https://github.com/glayzzle/php-parser/pull/249, but they related to other issues  https://github.com/prettier/plugin-php/issues/890 and https://github.com/prettier/plugin-php/issues/891, so we update snapshot after update parser again

fixes #870