### PR TITLE
fix: avoid extra parens around call argument

### DIFF
--- a/src/needs-parens.js
+++ b/src/needs-parens.js
@@ -176,6 +176,8 @@ function needsParens(path) {
         return false;
       } else if (parent.kind === "silent") {
         return false;
+      } else if (parent.kind === "call") {
+        return false;
       }
 
       return true;

--- a/tests/call/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/call/__snapshots__/jsfmt.spec.js.snap
@@ -403,7 +403,7 @@ tap(((int) $raw['data']) + $value, function ($newValue) use ($key, $raw) {
     $this->put($key, $newValue, $raw['time']);
 });
 
-$expire = substr(($contents = $this->files->get($path, true)), 0, 10);
+$expire = substr($contents = $this->files->get($path, true), 0, 10);
 $this->app->singleton('session', function ($app) {
     return new SessionManager($app);
 });

--- a/tests/parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/parens/__snapshots__/jsfmt.spec.js.snap
@@ -1075,6 +1075,16 @@ $var = (array(new Foo, "baz"))();
 $var = ((string) 1234)();
 $var = "Foo::bar"();
 $var = ("Foo::bar")();
+
+call(($a), (($b)), ((($c))));
+call($a = $b);
+call(($a = $b));
+call($a = new Foo());
+call(($a = new Foo()));
+call($a = (new Foo()));
+call(($a = (new Foo())));
+$foo->call(($a = (new Foo())));
+Foo::call(($a = (new Foo())));
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 
@@ -1119,6 +1129,16 @@ $var = (array(new Foo(), "baz"))();
 $var = ((string) 1234)();
 $var = ("Foo::bar")();
 $var = ("Foo::bar")();
+
+call($a, $b, $c);
+call($a = $b);
+call($a = $b);
+call($a = new Foo());
+call($a = new Foo());
+call($a = new Foo());
+call($a = new Foo());
+$foo->call($a = new Foo());
+Foo::call($a = new Foo());
 
 `;
 
@@ -1547,6 +1567,12 @@ switch (($var = 1)) {}
 
 while (list($id, $name, $salary) = $result->fetch(PDO::FETCH_NUM)) {}
 while ([$id, $name, $salary] = $result->fetch(PDO::FETCH_NUM)) {}
+
+if (($foo = $bar) && count($foo) > 0) {}
+if( false !== ($file = readdir($dh)) && 0 !== strpos($file,'.')){}
+while (($a = foo()) !== 5) {}
+while( false !== ($file = readdir($dh))){}
+do {} while( false !== ($file = readdir($dh)));
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <?php
 
@@ -1658,6 +1684,17 @@ while (list($id, $name, $salary) = $result->fetch(PDO::FETCH_NUM)) {
 }
 while ([$id, $name, $salary] = $result->fetch(PDO::FETCH_NUM)) {
 }
+
+if (($foo = $bar) && count($foo) > 0) {
+}
+if (false !== ($file = readdir($dh)) && 0 !== strpos($file, '.')) {
+}
+while (($a = foo()) !== 5) {
+}
+while (false !== ($file = readdir($dh))) {
+}
+do {
+} while (false !== ($file = readdir($dh)));
 
 `;
 

--- a/tests/parens/call.php
+++ b/tests/parens/call.php
@@ -41,3 +41,13 @@ $var = (array(new Foo, "baz"))();
 $var = ((string) 1234)();
 $var = "Foo::bar"();
 $var = ("Foo::bar")();
+
+call(($a), (($b)), ((($c))));
+call($a = $b);
+call(($a = $b));
+call($a = new Foo());
+call(($a = new Foo()));
+call($a = (new Foo()));
+call(($a = (new Foo())));
+$foo->call(($a = (new Foo())));
+Foo::call(($a = (new Foo())));

--- a/tests/parens/control-structures.php
+++ b/tests/parens/control-structures.php
@@ -86,3 +86,9 @@ switch (($var = 1)) {}
 
 while (list($id, $name, $salary) = $result->fetch(PDO::FETCH_NUM)) {}
 while ([$id, $name, $salary] = $result->fetch(PDO::FETCH_NUM)) {}
+
+if (($foo = $bar) && count($foo) > 0) {}
+if( false !== ($file = readdir($dh)) && 0 !== strpos($file,'.')){}
+while (($a = foo()) !== 5) {}
+while( false !== ($file = readdir($dh))){}
+do {} while( false !== ($file = readdir($dh)));


### PR DESCRIPTION
fixes #857

It is really popular practice in many code bases like `laravel`, `symfony`, `wordpress` and etc.