### PR TITLE
refactor: try/catch/finally

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -483,8 +483,22 @@ function isLookupNode(node) {
   );
 }
 
+function shouldPrintHardLineAfterStartInControlStructure(path) {
+  const node = path.getValue();
+
+  if (["try", "catch"].includes(node.kind)) {
+    return false;
+  }
+
+  return isFirstChildrenInlineNode(path);
+}
+
 function shouldPrintHardLineBeforeEndInControlStructure(path) {
   const node = path.getValue();
+
+  if (["try", "catch"].includes(node.kind)) {
+    return true;
+  }
 
   if (node.kind === "switch") {
     const children = getNodeListProperty(node.body);
@@ -766,6 +780,7 @@ module.exports = {
   docShouldHaveTrailingNewline,
   isLookupNode,
   isFirstChildrenInlineNode,
+  shouldPrintHardLineAfterStartInControlStructure,
   shouldPrintHardLineBeforeEndInControlStructure,
   getAlignment,
   getFirstNestedChildNode,


### PR DESCRIPTION
prepare for #829, also refactor, now we use `printBodyControlStructure` for all `control` structures, it is allow improve `inline` node printing for some cases