### PR TITLE
chore: deps update parser

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,14 +11,15 @@ build: off
 deploy: off
 
 cache:
-  - node_modules
-  - "%LOCALAPPDATA%/Yarn"
+  - node_modules -> appveyor.yml, package.json, yarn.lock
+  - "%LOCALAPPDATA%/Yarn -> appveyor.yml, package.json, yarn.lock"
 
 install:
   - ps: Install-Product node $env:nodejs_version
   - cmd: npm -v
   - cmd: node -v
   - cmd: npm install -g yarn
+  - cmd: yarn --version
   - cmd: yarn
 
 test_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ install:
   # TODO: Temporary solution after resolve https://github.com/salesforce/tough-cookie/issues/140
   - yarn install --ignore-engines
 script:
-  - AST_COMPARE=1 yarn test -- --runInBand
+  - AST_COMPARE=1 yarn test
   - yarn codecov

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "mem": "^4.0.0",
-    "php-parser": "glayzzle/php-parser#3.0.0-prerelease.8"
+    "php-parser": "glayzzle/php-parser#e451baa6ce2f0ef422f16a3458c5ac4e7c2ac4d4"
   },
   "devDependencies": {
     "codecov": "3.1.0",

--- a/src/util.js
+++ b/src/util.js
@@ -299,14 +299,15 @@ function docShouldHaveTrailingNewline(path) {
     return true;
   }
 
-  if (
-    (parent.kind === "assign" &&
-      parent.right === node &&
-      parentParent &&
-      parentParent.kind === "static") ||
-    parent.kind === "entry"
-  ) {
-    if (parent.kind === "entry" && parent.key === node) {
+  if (parent.kind === "staticvariable") {
+    const lastIndex = parentParent.variables.length - 1;
+    const index = parentParent.variables.indexOf(parent);
+
+    return index !== lastIndex;
+  }
+
+  if (parent.kind === "entry") {
+    if (parent.key === node) {
       return true;
     }
 

--- a/tests/classconstant/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/classconstant/__snapshots__/jsfmt.spec.js.snap
@@ -54,6 +54,22 @@ EOD;
     const FIRST_1 = "Hello", VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_SECOND = "world", THIRD_2 = "!";
     const VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_FIRST_FIRST = "Hello", VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_SECOND_1 = "world", VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_FIRST_THIRD = "!";
     const CONST_15 = ['key' => 'value', 'other-key' => 'other-value', 'other-other-key' => 'other-other-value'], FOO_BAR = "test", BAR_FOOR = ['value', 'other-value'];
+
+    const ARRAY_1 = ['value', 'other-value'], ARRAY_2 = ['value', 'other-value'];
+    const STRING =
+        'string' .
+        'string' .
+        'string' .
+        'string' .
+        'string' .
+        'string' .
+        'string' .
+        'string';
+    const FOOF = 'string
+string
+string', BAAR = 'string
+string
+string';
 }
 
 =====================================output=====================================
@@ -132,7 +148,9 @@ EOD;
         'other-other-key' => 'other-other-value'
     ];
 
-    const FIRST = "Hello", SECOND = "world", THIRD = "!";
+    const FIRST = "Hello",
+        SECOND = "world",
+        THIRD = "!";
     const VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_FIRST = "Hello",
         SECOND_1 = "world",
         THIRD_1 = "!";
@@ -149,6 +167,24 @@ EOD;
         ],
         FOO_BAR = "test",
         BAR_FOOR = ['value', 'other-value'];
+
+    const ARRAY_1 = ['value', 'other-value'],
+        ARRAY_2 = ['value', 'other-value'];
+    const STRING =
+        'string' .
+        'string' .
+        'string' .
+        'string' .
+        'string' .
+        'string' .
+        'string' .
+        'string';
+    const FOOF = 'string
+string
+string',
+        BAAR = 'string
+string
+string';
 }
 
 ================================================================================

--- a/tests/classconstant/classconstant.php
+++ b/tests/classconstant/classconstant.php
@@ -46,4 +46,20 @@ EOD;
     const FIRST_1 = "Hello", VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_SECOND = "world", THIRD_2 = "!";
     const VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_FIRST_FIRST = "Hello", VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_SECOND_1 = "world", VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_FIRST_THIRD = "!";
     const CONST_15 = ['key' => 'value', 'other-key' => 'other-value', 'other-other-key' => 'other-other-value'], FOO_BAR = "test", BAR_FOOR = ['value', 'other-value'];
+
+    const ARRAY_1 = ['value', 'other-value'], ARRAY_2 = ['value', 'other-value'];
+    const STRING =
+        'string' .
+        'string' .
+        'string' .
+        'string' .
+        'string' .
+        'string' .
+        'string' .
+        'string';
+    const FOOF = 'string
+string
+string', BAAR = 'string
+string
+string';
 }

--- a/tests/constant/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/constant/__snapshots__/jsfmt.spec.js.snap
@@ -21,6 +21,24 @@ const VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_FIRST = "Hello", SECOND = "world",
 const FIRST = "Hello", VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_SECOND = "world", THIRD = "!";
 const VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_FIRST_FIRST = "Hello", VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_SECOND = "world", VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_FIRST_THIRD = "!";
 
+const ARRAY_1 = ['value', 'other-value'], ARRAY_2 = ['value', 'other-value'];
+
+const STRING =
+    'string' .
+    'string' .
+    'string' .
+    'string' .
+    'string' .
+    'string' .
+    'string' .
+    'string';
+
+const FOOF = 'string
+string
+string', BAAR = 'string
+string
+string';
+
 =====================================output=====================================
 <?php
 define("TEST_CONSTANT", 1);
@@ -32,7 +50,9 @@ const TWO = ONE * 2;
 $test = TEST_CONSTANT;
 $test = OTHER_TEST_CONSTANT;
 
-const FIRST = "Hello", SECOND = "world", THIRD = "!";
+const FIRST = "Hello",
+    SECOND = "world",
+    THIRD = "!";
 const VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_FIRST = "Hello",
     SECOND = "world",
     THIRD = "!";
@@ -42,6 +62,26 @@ const FIRST = "Hello",
 const VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_FIRST_FIRST = "Hello",
     VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_SECOND = "world",
     VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_FIRST_THIRD = "!";
+
+const ARRAY_1 = ['value', 'other-value'],
+    ARRAY_2 = ['value', 'other-value'];
+
+const STRING =
+    'string' .
+    'string' .
+    'string' .
+    'string' .
+    'string' .
+    'string' .
+    'string' .
+    'string';
+
+const FOOF = 'string
+string
+string',
+    BAAR = 'string
+string
+string';
 
 ================================================================================
 `;

--- a/tests/constant/constants.php
+++ b/tests/constant/constants.php
@@ -12,3 +12,21 @@ const FIRST = "Hello", SECOND = "world", THIRD = "!";
 const VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_FIRST = "Hello", SECOND = "world", THIRD = "!";
 const FIRST = "Hello", VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_SECOND = "world", THIRD = "!";
 const VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_FIRST_FIRST = "Hello", VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_SECOND = "world", VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_FIRST_THIRD = "!";
+
+const ARRAY_1 = ['value', 'other-value'], ARRAY_2 = ['value', 'other-value'];
+
+const STRING =
+    'string' .
+    'string' .
+    'string' .
+    'string' .
+    'string' .
+    'string' .
+    'string' .
+    'string';
+
+const FOOF = 'string
+string
+string', BAAR = 'string
+string
+string';

--- a/yarn.lock
+++ b/yarn.lock
@@ -695,9 +695,9 @@ copy-descriptor@^0.1.0:
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
 core-js@^2.4.0, core-js@^2.5.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.2.tgz#267988d7268323b349e20b4588211655f0e83944"
-  integrity sha512-NdBPF/RVwPW6jr0NCILuyN9RiqLo2b1mddWHkUL+VnvcB7dzlnBJ1bXYntjpTGOgkZiiLWj2JxmOr7eGE3qK6g==
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.3.tgz#4b70938bdffdaf64931e66e2db158f0892289c49"
+  integrity sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -3124,9 +3124,9 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-php-parser@glayzzle/php-parser#3.0.0-prerelease.8:
+php-parser@glayzzle/php-parser#e451baa6ce2f0ef422f16a3458c5ac4e7c2ac4d4:
   version "3.0.0-prerelease.8"
-  resolved "https://codeload.github.com/glayzzle/php-parser/tar.gz/2c2e63d94f6971bd3d84472aee6bd00bcf8e7f73"
+  resolved "https://codeload.github.com/glayzzle/php-parser/tar.gz/e451baa6ce2f0ef422f16a3458c5ac4e7c2ac4d4"
 
 pify@^2.0.0:
   version "2.3.0"
@@ -4175,9 +4175,9 @@ wrappy@1:
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
 write-file-atomic@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
-  integrity sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.2.tgz#a7181706dfba17855d221140a9c06e15fcdd87b9"
+  integrity sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==
   dependencies:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"


### PR DESCRIPTION
Includes:
- Change `static` ast printing
- Fixed `constantstatement` and `classconstant` printing with `value` as prettier format `const`/`let`/`var`
- Tests

Before we use same algorithm for `*constant` and `static` nodes. Now they are same in some places, but it is really difference ast, also `*constant` nodes ast will be changed in near future