### PR TITLE
refactor: simplify code for `traituse` node

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1651,7 +1651,29 @@ function printNode(path, options, print) {
                       indent(
                         concat([
                           hardline,
-                          printLines(path, options, print, "adaptations")
+                          concat(
+                            path.map(childPath => {
+                              const parts = [];
+
+                              parts.push(print(childPath));
+
+                              if (!isLastStatement(childPath)) {
+                                parts.push(hardline);
+
+                                if (
+                                  isNextLineEmpty(
+                                    options.originalText,
+                                    childPath.getValue(),
+                                    options
+                                  )
+                                ) {
+                                  parts.push(hardline);
+                                }
+                              }
+
+                              return concat(parts);
+                            }, "adaptations")
+                          )
                         ])
                       ),
                       hardline

--- a/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
@@ -624,3 +624,126 @@ $a = 1;
 
 ================================================================================
 `;
+
+exports[`traituse.php 1`] = `
+====================================options=====================================
+parsers: ["php"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+class Aliased_Talker {
+
+
+    use A, B {
+
+
+        B::smallTalk insteadof A;
+
+
+        A::bigTalk insteadof B;
+
+        B::smallTalk insteadof A;
+        A::bigTalk insteadof B;
+
+        B::bigTalk as talk;
+
+        // Comment
+        B::smallTalk insteadof A;
+
+        // Comment
+        B::smallTalk insteadof A; // Comment
+        // Comment
+
+        // Comment
+
+        B::smallTalk insteadof A;
+
+
+    }
+
+    use C {
+        C::smallTalk insteadof A;
+    }
+
+    use D {
+        // Comment
+        D::smallTalk insteadof A;
+        // Comment
+    }
+
+
+
+    use D {
+
+
+    }
+
+    use E {
+
+        E::smallTalk insteadof A;
+
+    }
+
+    use F {
+        // Comment
+        F::smallTalk insteadof A;
+        // Comment
+    }
+
+
+}
+
+=====================================output=====================================
+<?php
+
+class Aliased_Talker
+{
+    use A, B {
+        B::smallTalk insteadof A;
+
+        A::bigTalk insteadof B;
+
+        B::smallTalk insteadof A;
+        A::bigTalk insteadof B;
+
+        B::bigTalk as talk;
+
+        // Comment
+        B::smallTalk insteadof A;
+
+        // Comment
+        B::smallTalk insteadof A; // Comment
+        // Comment
+
+        // Comment
+
+        B::smallTalk insteadof A;
+    }
+
+    use C {
+        C::smallTalk insteadof A;
+    }
+
+    use D {
+        // Comment
+        D::smallTalk insteadof A;
+        // Comment
+    }
+
+    use D {}
+
+    use E {
+        E::smallTalk insteadof A;
+    }
+
+    use F {
+        // Comment
+        F::smallTalk insteadof A;
+        // Comment
+    }
+}
+
+================================================================================
+`;

--- a/tests/preserve_line/traituse.php
+++ b/tests/preserve_line/traituse.php
@@ -1,0 +1,63 @@
+<?php
+
+class Aliased_Talker {
+
+
+    use A, B {
+
+
+        B::smallTalk insteadof A;
+
+
+        A::bigTalk insteadof B;
+
+        B::smallTalk insteadof A;
+        A::bigTalk insteadof B;
+
+        B::bigTalk as talk;
+
+        // Comment
+        B::smallTalk insteadof A;
+
+        // Comment
+        B::smallTalk insteadof A; // Comment
+        // Comment
+
+        // Comment
+
+        B::smallTalk insteadof A;
+
+
+    }
+
+    use C {
+        C::smallTalk insteadof A;
+    }
+
+    use D {
+        // Comment
+        D::smallTalk insteadof A;
+        // Comment
+    }
+
+
+
+    use D {
+
+
+    }
+
+    use E {
+
+        E::smallTalk insteadof A;
+
+    }
+
+    use F {
+        // Comment
+        F::smallTalk insteadof A;
+        // Comment
+    }
+
+
+}


### PR DESCRIPTION
Just refactor + tests, increase print speed, `traituse` can't contain inline nodes