### PR TITLE
refactor: simplify class body printing

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1251,7 +1251,29 @@ function printClass(path, options, print) {
     indent(
       concat([
         hasEmptyClassBody ? "" : hardline,
-        printLines(path, options, print, "body")
+        concat(
+          path.map(childPath => {
+            const parts = [];
+
+            parts.push(print(childPath));
+
+            if (!isLastStatement(childPath)) {
+              parts.push(hardline);
+
+              if (
+                isNextLineEmpty(
+                  options.originalText,
+                  childPath.getValue(),
+                  options
+                )
+              ) {
+                parts.push(hardline);
+              }
+            }
+
+            return concat(parts);
+          }, "body")
+        )
       ])
     ),
     comments.printDanglingComments(path, options, true),

--- a/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
@@ -364,6 +364,110 @@ doSomething(
 ================================================================================
 `;
 
+exports[`class.php 1`] = `
+====================================options=====================================
+parsers: ["php"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+class Foo
+{
+
+
+    // property declaration
+    public $var = 'a default value';
+    public $var_1 = 'a default value';
+
+
+    public $var_2 = 'a default value';
+
+    // method declaration
+    public function displayVar() {
+        echo $this->var;
+    }
+    public function displayVar1() {
+        echo $this->var_1;
+    }
+
+
+    public function displayVar2() {
+        echo $this->var_2;
+    }
+
+    const CONSTANT = 'constant value';
+    const CONSTANT_1 = 'constant value';
+
+
+    const CONSTANT_2 = 'constant value';
+
+    // Comment
+
+
+    // Comment
+    public function __sleep()
+    {
+        return array('dsn', 'username', 'password');
+    }
+    // Comment
+
+
+    // Comment
+    private $dsn;
+    // Comment
+
+
+}
+
+=====================================output=====================================
+<?php
+
+class Foo
+{
+    // property declaration
+    public $var = 'a default value';
+    public $var_1 = 'a default value';
+
+    public $var_2 = 'a default value';
+
+    // method declaration
+    public function displayVar()
+    {
+        echo $this->var;
+    }
+    public function displayVar1()
+    {
+        echo $this->var_1;
+    }
+
+    public function displayVar2()
+    {
+        echo $this->var_2;
+    }
+
+    const CONSTANT = 'constant value';
+    const CONSTANT_1 = 'constant value';
+
+    const CONSTANT_2 = 'constant value';
+
+    // Comment
+
+    // Comment
+    public function __sleep()
+    {
+        return array('dsn', 'username', 'password');
+    }
+    // Comment
+
+    // Comment
+    private $dsn;
+    // Comment
+}
+
+================================================================================
+`;
+
 exports[`comments.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]

--- a/tests/preserve_line/class.php
+++ b/tests/preserve_line/class.php
@@ -1,0 +1,49 @@
+<?php
+
+class Foo
+{
+
+
+    // property declaration
+    public $var = 'a default value';
+    public $var_1 = 'a default value';
+
+
+    public $var_2 = 'a default value';
+
+    // method declaration
+    public function displayVar() {
+        echo $this->var;
+    }
+    public function displayVar1() {
+        echo $this->var_1;
+    }
+
+
+    public function displayVar2() {
+        echo $this->var_2;
+    }
+
+    const CONSTANT = 'constant value';
+    const CONSTANT_1 = 'constant value';
+
+
+    const CONSTANT_2 = 'constant value';
+
+    // Comment
+
+
+    // Comment
+    public function __sleep()
+    {
+        return array('dsn', 'username', 'password');
+    }
+    // Comment
+
+
+    // Comment
+    private $dsn;
+    // Comment
+
+
+}


### PR DESCRIPTION
Refactor + tests, `class`/`trait`/`interface` can't contain `inline`