### PR TITLE
feat: normalize case of magic methods

### DIFF
--- a/src/clean.js
+++ b/src/clean.js
@@ -96,6 +96,10 @@ function clean(node, newObj) {
     newObj.name = newObj.name.replace(/^\\/, "");
   }
 
+  if (node.kind === "method" && node.name.kind === "identifier") {
+    newObj.name.name = util.normalizeMagicMethodName(newObj.name.name);
+  }
+
   // @TODO: We need special node for `null` value to avoid ast compare problem
   if (node.kind === "classreference" && node.name.toLowerCase() === "null") {
     delete newObj.name;

--- a/src/printer.js
+++ b/src/printer.js
@@ -57,7 +57,8 @@ const {
   isDocNode,
   getAncestorNode,
   isReferenceLikeNode,
-  getNextNode
+  getNextNode,
+  normalizeMagicMethodName
 } = require("./util");
 
 function shouldPrintComma(options, level) {
@@ -2780,6 +2781,12 @@ function printNode(path, options, print) {
     case "typereference":
       return node.name;
     case "identifier": {
+      const parent = path.getParentNode();
+
+      if (parent.kind === "method") {
+        node.name = normalizeMagicMethodName(node.name);
+      }
+
       return path.call(print, "name");
     }
     case "error":

--- a/src/util.js
+++ b/src/util.js
@@ -670,6 +670,39 @@ function getAncestorNode(path, typeOrTypes) {
   return counter === -1 ? null : path.getParentNode(counter);
 }
 
+const magicMethods = [
+  "__construct",
+  "__destruct",
+  "__call",
+  "__callStatic",
+  "__get",
+  "__set",
+  "__isset",
+  "__unset",
+  "__sleep",
+  "__wakeup",
+  "__toString",
+  "__invoke",
+  "__set_state",
+  "__clone",
+  "__debugInfo"
+];
+const MagicMethodsMap = magicMethods.reduce((map, obj) => {
+  map[obj.toLowerCase()] = obj;
+
+  return map;
+}, {});
+
+function normalizeMagicMethodName(name) {
+  const loweredName = name.toLowerCase();
+
+  if (MagicMethodsMap[loweredName]) {
+    return MagicMethodsMap[loweredName];
+  }
+
+  return name;
+}
+
 module.exports = {
   printNumber,
   getPrecedence,
@@ -705,5 +738,6 @@ module.exports = {
   shouldPrintHardlineBeforeTrailingComma,
   isDocNode,
   getAncestorNode,
-  getNextNode
+  getNextNode,
+  normalizeMagicMethodName
 };

--- a/tests/case/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/case/__snapshots__/jsfmt.spec.js.snap
@@ -496,3 +496,149 @@ __halt_compiler();
 
 ================================================================================
 `;
+
+exports[`magic-methods.php 1`] = `
+====================================options=====================================
+parsers: ["php"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+// The function names __construct(), __destruct(), __call(), __callStatic(), __get(), __set(), __isset(), __unset(), __sleep(), __wakeup(), __toString(), __invoke(), __set_state(), __clone() and __debugInfo() are magical in PHP classes.
+// You cannot have functions with these names in any of your classes unless you want the magic functionality associated with them.
+
+class Connection
+{
+    public function __CONSTRUCT()
+    {
+    }
+
+    public function __DESTRUCT()
+    {
+    }
+
+    public function __CALL($name, $arguments)
+    {
+    }
+
+    public static function __CALLSTATIC($name, $arguments)
+    {
+    }
+
+    public function __GET($name)
+    {
+    }
+
+    public function __SET($name, $value)
+    {
+    }
+
+    public function __ISSET($name)
+    {
+    }
+
+    public function __UNSET($name)
+    {
+    }
+
+    public function __SLEEP()
+    {
+    }
+
+    public function __WAKEUP()
+    {
+    }
+
+    public function __TOSTRING()
+    {
+    }
+
+    public function __INVOKE($x)
+    {
+    }
+
+    public function __SET_STATE($an_array)
+    {
+    }
+
+    public function __CLONE()
+    {
+    }
+
+    public function __DEBUGINFO()
+    {
+    }
+}
+
+=====================================output=====================================
+<?php
+
+// The function names __construct(), __destruct(), __call(), __callStatic(), __get(), __set(), __isset(), __unset(), __sleep(), __wakeup(), __toString(), __invoke(), __set_state(), __clone() and __debugInfo() are magical in PHP classes.
+// You cannot have functions with these names in any of your classes unless you want the magic functionality associated with them.
+
+class Connection
+{
+    public function __construct()
+    {
+    }
+
+    public function __destruct()
+    {
+    }
+
+    public function __call($name, $arguments)
+    {
+    }
+
+    public static function __callStatic($name, $arguments)
+    {
+    }
+
+    public function __get($name)
+    {
+    }
+
+    public function __set($name, $value)
+    {
+    }
+
+    public function __isset($name)
+    {
+    }
+
+    public function __unset($name)
+    {
+    }
+
+    public function __sleep()
+    {
+    }
+
+    public function __wakeup()
+    {
+    }
+
+    public function __toString()
+    {
+    }
+
+    public function __invoke($x)
+    {
+    }
+
+    public function __set_state($an_array)
+    {
+    }
+
+    public function __clone()
+    {
+    }
+
+    public function __debugInfo()
+    {
+    }
+}
+
+================================================================================
+`;

--- a/tests/case/magic-methods.php
+++ b/tests/case/magic-methods.php
@@ -1,0 +1,67 @@
+<?php
+
+// The function names __construct(), __destruct(), __call(), __callStatic(), __get(), __set(), __isset(), __unset(), __sleep(), __wakeup(), __toString(), __invoke(), __set_state(), __clone() and __debugInfo() are magical in PHP classes.
+// You cannot have functions with these names in any of your classes unless you want the magic functionality associated with them.
+
+class Connection
+{
+    public function __CONSTRUCT()
+    {
+    }
+
+    public function __DESTRUCT()
+    {
+    }
+
+    public function __CALL($name, $arguments)
+    {
+    }
+
+    public static function __CALLSTATIC($name, $arguments)
+    {
+    }
+
+    public function __GET($name)
+    {
+    }
+
+    public function __SET($name, $value)
+    {
+    }
+
+    public function __ISSET($name)
+    {
+    }
+
+    public function __UNSET($name)
+    {
+    }
+
+    public function __SLEEP()
+    {
+    }
+
+    public function __WAKEUP()
+    {
+    }
+
+    public function __TOSTRING()
+    {
+    }
+
+    public function __INVOKE($x)
+    {
+    }
+
+    public function __SET_STATE($an_array)
+    {
+    }
+
+    public function __CLONE()
+    {
+    }
+
+    public function __DEBUGINFO()
+    {
+    }
+}


### PR DESCRIPTION
Normalize case of magic methods, PHP allow use any case for this (like `__CONSTRUCT`, `__CoNsTrUcT`, '`__construct`) and all cases are valid and works, so let's normalize case of them to lower