### PR TITLE
fix: better print multiline function and method declaration

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1371,6 +1371,12 @@ function printFunction(path, options, print) {
     ]);
   }
 
+  const willBreakDeclaration = declaration.some(willBreak);
+
+  if (willBreakDeclaration) {
+    return concat([printedDeclaration, " ", printedBody]);
+  }
+
   return conditionalGroup([
     concat([
       printedDeclaration,

--- a/tests/brace-style/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/brace-style/__snapshots__/jsfmt.spec.js.snap
@@ -734,6 +734,44 @@ class Foo
     }
 
     static function staticmethod() {}
+
+    public static function ellipsizeMiddle(
+        $string,
+        $max_length,
+        // @codingStandardsIgnoreLine
+        $ellipses = ' … ', // the spaces are non-breaking spaces
+        &$flag = null
+    ) {
+        $string = trim($string);
+    }
+
+    public static function hello_2() {}
+
+    public static function hello_3($var = 1) {}
+
+    public static function hello_4($var = 1, $other_var = 2, $other_other_other_var = 3) {}
+
+    public static function hello_5($var = 1, $other_var = 2, $other_other_other_var = 3): ?string {}
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName() {}
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName($var = 1) {}
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName($var = 1, $other_var = 2, $other_other_other_var = 3) {}
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName($var = 1, $other_var = 2, $other_other_other_var = 3) : ?string {}
+
+    public static function newlines(
+        $var = 1,
+
+        $other_var = 2
+    ) {}
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName(
+        $var = 1,
+
+        $other_var = 2
+    ) {}
 }
 
 =====================================output=====================================
@@ -808,6 +846,75 @@ class Foo
 
     static function staticmethod()
     {
+    }
+
+    public static function ellipsizeMiddle(
+        $string,
+        $max_length,
+        // @codingStandardsIgnoreLine
+        $ellipses = ' … ', // the spaces are non-breaking spaces
+        &$flag = null
+    ) {
+        $string = trim($string);
+    }
+
+    public static function hello_2()
+    {
+    }
+
+    public static function hello_3($var = 1)
+    {
+    }
+
+    public static function hello_4(
+        $var = 1,
+        $other_var = 2,
+        $other_other_other_var = 3
+    ) {
+    }
+
+    public static function hello_5(
+        $var = 1,
+        $other_var = 2,
+        $other_other_other_var = 3
+    ): ?string {
+    }
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName()
+    {
+    }
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName(
+        $var = 1
+    ) {
+    }
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName(
+        $var = 1,
+        $other_var = 2,
+        $other_other_other_var = 3
+    ) {
+    }
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName(
+        $var = 1,
+        $other_var = 2,
+        $other_other_other_var = 3
+    ): ?string {
+    }
+
+    public static function newlines(
+        $var = 1,
+
+        $other_var = 2
+    ) {
+    }
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName(
+        $var = 1,
+
+        $other_var = 2
+    ) {
     }
 }
 
@@ -879,6 +986,44 @@ class Foo
     }
 
     static function staticmethod() {}
+
+    public static function ellipsizeMiddle(
+        $string,
+        $max_length,
+        // @codingStandardsIgnoreLine
+        $ellipses = ' … ', // the spaces are non-breaking spaces
+        &$flag = null
+    ) {
+        $string = trim($string);
+    }
+
+    public static function hello_2() {}
+
+    public static function hello_3($var = 1) {}
+
+    public static function hello_4($var = 1, $other_var = 2, $other_other_other_var = 3) {}
+
+    public static function hello_5($var = 1, $other_var = 2, $other_other_other_var = 3): ?string {}
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName() {}
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName($var = 1) {}
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName($var = 1, $other_var = 2, $other_other_other_var = 3) {}
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName($var = 1, $other_var = 2, $other_other_other_var = 3) : ?string {}
+
+    public static function newlines(
+        $var = 1,
+
+        $other_var = 2
+    ) {}
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName(
+        $var = 1,
+
+        $other_var = 2
+    ) {}
 }
 
 =====================================output=====================================
@@ -954,6 +1099,75 @@ class Foo
     static function staticmethod()
     {
     }
+
+    public static function ellipsizeMiddle(
+        $string,
+        $max_length,
+        // @codingStandardsIgnoreLine
+        $ellipses = ' … ', // the spaces are non-breaking spaces
+        &$flag = null
+    ) {
+        $string = trim($string);
+    }
+
+    public static function hello_2()
+    {
+    }
+
+    public static function hello_3($var = 1)
+    {
+    }
+
+    public static function hello_4(
+        $var = 1,
+        $other_var = 2,
+        $other_other_other_var = 3
+    ) {
+    }
+
+    public static function hello_5(
+        $var = 1,
+        $other_var = 2,
+        $other_other_other_var = 3
+    ): ?string {
+    }
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName()
+    {
+    }
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName(
+        $var = 1
+    ) {
+    }
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName(
+        $var = 1,
+        $other_var = 2,
+        $other_other_other_var = 3
+    ) {
+    }
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName(
+        $var = 1,
+        $other_var = 2,
+        $other_other_other_var = 3
+    ): ?string {
+    }
+
+    public static function newlines(
+        $var = 1,
+
+        $other_var = 2
+    ) {
+    }
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName(
+        $var = 1,
+
+        $other_var = 2
+    ) {
+    }
 }
 
 ================================================================================
@@ -1024,6 +1238,44 @@ class Foo
     }
 
     static function staticmethod() {}
+
+    public static function ellipsizeMiddle(
+        $string,
+        $max_length,
+        // @codingStandardsIgnoreLine
+        $ellipses = ' … ', // the spaces are non-breaking spaces
+        &$flag = null
+    ) {
+        $string = trim($string);
+    }
+
+    public static function hello_2() {}
+
+    public static function hello_3($var = 1) {}
+
+    public static function hello_4($var = 1, $other_var = 2, $other_other_other_var = 3) {}
+
+    public static function hello_5($var = 1, $other_var = 2, $other_other_other_var = 3): ?string {}
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName() {}
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName($var = 1) {}
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName($var = 1, $other_var = 2, $other_other_other_var = 3) {}
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName($var = 1, $other_var = 2, $other_other_other_var = 3) : ?string {}
+
+    public static function newlines(
+        $var = 1,
+
+        $other_var = 2
+    ) {}
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName(
+        $var = 1,
+
+        $other_var = 2
+    ) {}
 }
 
 =====================================output=====================================
@@ -1089,6 +1341,72 @@ class Foo {
     }
 
     static function staticmethod() {
+    }
+
+    public static function ellipsizeMiddle(
+        $string,
+        $max_length,
+        // @codingStandardsIgnoreLine
+        $ellipses = ' … ', // the spaces are non-breaking spaces
+        &$flag = null
+    ) {
+        $string = trim($string);
+    }
+
+    public static function hello_2() {
+    }
+
+    public static function hello_3($var = 1) {
+    }
+
+    public static function hello_4(
+        $var = 1,
+        $other_var = 2,
+        $other_other_other_var = 3
+    ) {
+    }
+
+    public static function hello_5(
+        $var = 1,
+        $other_var = 2,
+        $other_other_other_var = 3
+    ): ?string {
+    }
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName() {
+    }
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName(
+        $var = 1
+    ) {
+    }
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName(
+        $var = 1,
+        $other_var = 2,
+        $other_other_other_var = 3
+    ) {
+    }
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName(
+        $var = 1,
+        $other_var = 2,
+        $other_other_other_var = 3
+    ): ?string {
+    }
+
+    public static function newlines(
+        $var = 1,
+
+        $other_var = 2
+    ) {
+    }
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName(
+        $var = 1,
+
+        $other_var = 2
+    ) {
     }
 }
 

--- a/tests/brace-style/methods.php
+++ b/tests/brace-style/methods.php
@@ -56,4 +56,42 @@ class Foo
     }
 
     static function staticmethod() {}
+
+    public static function ellipsizeMiddle(
+        $string,
+        $max_length,
+        // @codingStandardsIgnoreLine
+        $ellipses = ' … ', // the spaces are non-breaking spaces
+        &$flag = null
+    ) {
+        $string = trim($string);
+    }
+
+    public static function hello_2() {}
+
+    public static function hello_3($var = 1) {}
+
+    public static function hello_4($var = 1, $other_var = 2, $other_other_other_var = 3) {}
+
+    public static function hello_5($var = 1, $other_var = 2, $other_other_other_var = 3): ?string {}
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName() {}
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName($var = 1) {}
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName($var = 1, $other_var = 2, $other_other_other_var = 3) {}
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName($var = 1, $other_var = 2, $other_other_other_var = 3) : ?string {}
+
+    public static function newlines(
+        $var = 1,
+
+        $other_var = 2
+    ) {}
+
+    public static function veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongName(
+        $var = 1,
+
+        $other_var = 2
+    ) {}
 }

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -3372,8 +3372,7 @@ function foo(
     // Comment
     string $b,
     bool $c // Comment
-)
-{
+) {
 }
 
 function foo()

--- a/tests/encapsed/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/encapsed/__snapshots__/jsfmt.spec.js.snap
@@ -464,8 +464,7 @@ using nowdoc syntax.
 EOF
     ,
     $c = 1
-)
-{
+) {
     echo $b;
 }
 
@@ -478,8 +477,7 @@ using nowdoc syntax.
 EOF
     ,
     $c = 1
-)
-{
+) {
     echo $b;
 }
 
@@ -490,8 +488,7 @@ Example of string
 spanning multiple lines
 using nowdoc syntax.
 EOF
-)
-{
+) {
     echo $b;
 }
 

--- a/tests/nowdoc/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/nowdoc/__snapshots__/jsfmt.spec.js.snap
@@ -991,8 +991,7 @@ using nowdoc syntax.
 EOD
     ,
     $c = 1
-)
-{
+) {
     echo $b;
 }
 
@@ -1005,8 +1004,7 @@ using nowdoc syntax.
 EOD
     ,
     $c = 1
-)
-{
+) {
     echo $b;
 }
 
@@ -1017,8 +1015,7 @@ Example of string
 spanning multiple lines
 using nowdoc syntax.
 EOD
-)
-{
+) {
     echo $b;
 }
 
@@ -1318,8 +1315,7 @@ string
 string
 string
 EOD
-    )
-    {
+    ) {
     }
     public function test1(
         $var,
@@ -1328,8 +1324,7 @@ string
 string
 string
 EOD
-    )
-    {
+    ) {
     }
     public function test2(
         $var = <<<'EOD'
@@ -1339,8 +1334,7 @@ string
 EOD
         ,
         $var
-    )
-    {
+    ) {
     }
 }
 

--- a/tests/parameter/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/parameter/__snapshots__/jsfmt.spec.js.snap
@@ -203,8 +203,7 @@ function bar1(
 
         "key3" => "veryVeryVeryVeryVeryVeryVeryVeryVeryLongString"
     )
-)
-{
+) {
     return $arg;
 }
 
@@ -247,8 +246,7 @@ function foo(
     $arg = 'string
 string
 string'
-)
-{
+) {
 }
 
 function foo(
@@ -258,8 +256,7 @@ string',
     $arg = 'string
 string
 string'
-)
-{
+) {
 }
 
 function foo(
@@ -268,8 +265,7 @@ function foo(
 string
 string',
     $c
-)
-{
+) {
 }
 
 ================================================================================


### PR DESCRIPTION
fixes #929

Looks we already have invalid printing in our code. Also we need implement `printFunctionParams` for function and method, now we use `printArgumentsList` and it is may output ugly paramaters in some very rare cases, also it is increase printing time. Let's do it in other PR