### PR TITLE
Implement Syntax Errors Matching Prettier Conventions, fixes #956

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "rollup-plugin-inject": "^2.2.0",
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-plugin-replace": "^2.1.0",
-    "rollup-plugin-terser": "^4.0.4"
+    "rollup-plugin-terser": "^4.0.4",
+    "strip-ansi": "^5.0.0"
   },
   "peerDependencies": {
     "prettier": "^1.15.0"

--- a/src/parser.js
+++ b/src/parser.js
@@ -24,7 +24,25 @@ function parse(text, parsers, opts) {
 
   const hasOpenPHPTag = text.indexOf("<?php") !== -1;
   const parseAsEval = inMarkdown && !hasOpenPHPTag;
-  const ast = parseAsEval ? parser.parseEval(text) : parser.parseCode(text);
+
+  let ast;
+  try {
+    ast = parseAsEval ? parser.parseEval(text) : parser.parseCode(text);
+  } catch (err) {
+    if (err instanceof SyntaxError && "lineNumber" in err) {
+      err.loc = {
+        start: {
+          line: err.lineNumber,
+          column: err.columnNumber
+        }
+      };
+
+      delete err.lineNumber;
+      delete err.columnNumber;
+    }
+
+    throw err;
+  }
 
   ast.extra = {
     parseAsEval

--- a/tests/syntax-error/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/syntax-error/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Syntax errors have the expected structure 1`] = `
+Object {
+  "codeFrame": "> 1 | <?php _
+    |       ^",
+  "fileName": "eval",
+  "loc": Object {
+    "start": Object {
+      "column": 7,
+      "line": 1,
+    },
+  },
+}
+`;

--- a/tests/syntax-error/jsfmt.spec.js
+++ b/tests/syntax-error/jsfmt.spec.js
@@ -1,0 +1,27 @@
+const { prettier, plugin } = require("../../tests_config/get_engine");
+const stripAnsi = require("strip-ansi");
+
+function raiseSyntaxError() {
+  prettier.format(`<?php _`, {
+    plugins: [plugin],
+    parser: "php"
+  });
+}
+
+test("Prettier throws SyntaxErrors", () => {
+  expect(raiseSyntaxError).toThrow(SyntaxError);
+});
+
+test("Syntax errors have the expected structure", () => {
+  try {
+    raiseSyntaxError();
+  } catch (err) {
+    // Convert error to plain object since additional properties are not snapshotted otherwise
+    const errObject = Object.assign({}, err, {
+      // Strip ANSI from code frame since not all test environments may support it
+      codeFrame: stripAnsi(err.codeFrame)
+    });
+
+    expect(errObject).toMatchSnapshot();
+  }
+});

--- a/tests/syntax-error/jsfmt.spec.js
+++ b/tests/syntax-error/jsfmt.spec.js
@@ -16,7 +16,7 @@ test("Syntax errors have the expected structure", () => {
   try {
     raiseSyntaxError();
   } catch (err) {
-    // Convert error to plain object since additional properties are not snapshotted otherwise
+    // Convert error to plain object since additional properties are not snapshotted otherwise
     const errObject = Object.assign({}, err, {
       // Strip ANSI from code frame since not all test environments may support it
       codeFrame: stripAnsi(err.codeFrame)

--- a/tests_config/get_engine.js
+++ b/tests_config/get_engine.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const path = require("path");
+
+if (global.STANDALONE) {
+  exports.prettier = require("prettier/standalone");
+  exports.plugin = require(path.join(__dirname, "..", "standalone.js"));
+} else {
+  exports.prettier = require("prettier");
+  exports.plugin = path.join(__dirname, "..");
+}

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -10,10 +10,7 @@ const CURSOR_PLACEHOLDER = "<|>";
 const RANGE_START_PLACEHOLDER = "<<<PRETTIER_RANGE_START>>>";
 const RANGE_END_PLACEHOLDER = "<<<PRETTIER_RANGE_END>>>";
 
-const prettier = require(`prettier${global.STANDALONE ? "/standalone" : ""}`);
-const plugin = global.STANDALONE
-  ? require(path.join(__dirname, "..", "standalone.js"))
-  : ".";
+const { prettier, plugin } = require("./get_engine");
 
 global.run_spec = (dirname, parsers, options) => {
   options = Object.assign({}, options, {


### PR DESCRIPTION
This PR changes the structure of `SyntaxError`s thrown from the PHP plugin towards Prettier in such a way that Prettier knows how to handle them, as explained in #956.

The small refactoring in the `tests_config` folder is a necessity for the added test that covers the new behavior, as this test is not matching the structure of the other `run_spec()` tests.