### PR TITLE
fix: trailing comment output when the printer returns a doc instead of a string

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -983,7 +983,10 @@ function printTrailingComment(commentPath, print, options) {
     return concat([" ", contents]);
   }
 
-  return concat([lineSuffix(` ${contents}`), !isBlock ? breakParent : ""]);
+  return concat([
+    lineSuffix(concat([" ", contents])),
+    !isBlock ? breakParent : ""
+  ]);
 }
 
 function printAllComments(path, print, options, needsSemi) {


### PR DESCRIPTION
Backport: https://github.com/prettier/prettier/pull/5930#issuecomment-469053975