### PR TITLE
Fixed heredoc inside function calls inside other function calls

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -258,7 +258,9 @@ function docShouldHaveTrailingNewline(path) {
   }
 
   if (
-    (parentParent && ["call", "new", "echo"].includes(parentParent.kind)) ||
+    (parentParent &&
+      ["call", "new", "echo"].includes(parentParent.kind) &&
+      parent.kind !== "call") ||
     parent.kind === "parameter"
   ) {
     const lastIndex = parentParent.arguments.length - 1;

--- a/tests/nowdoc/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/nowdoc/__snapshots__/jsfmt.spec.js.snap
@@ -52,6 +52,11 @@ foo
 EOD
 , true);
 
+$str = sprintf(sprintf(<<<END
+foo
+END
+, true));
+
 function foo($a = 1, $b = <<<'EOD'
 Example of string
 spanning multiple lines
@@ -980,6 +985,16 @@ foo
 EOD
     ,
     true
+);
+
+$str = sprintf(
+    sprintf(
+        <<<END
+foo
+END
+        ,
+        true
+    )
 );
 
 function foo(

--- a/tests/nowdoc/nowdoc.php
+++ b/tests/nowdoc/nowdoc.php
@@ -44,6 +44,11 @@ foo
 EOD
 , true);
 
+$str = sprintf(sprintf(<<<END
+foo
+END
+, true));
+
 function foo($a = 1, $b = <<<'EOD'
 Example of string
 spanning multiple lines


### PR DESCRIPTION
I found a formatting bug where heredoc inside of a function call inside of a second function call would format to a syntax error due to a comma being added after the heredoc delimiter.

Input:
```
$str = sprintf(sprintf(<<<EOD
foo
EOD
, true));
```

prettier output:
```
$str = sprintf(
    sprintf(
        <<<EOD
foo
EOD, 
        true
    )
);
```

correct output:
```
$str = sprintf(
    sprintf(
        <<<EOD
foo
EOD
        , 
        true
    )
);
```
