### PR TITLE
 Fixed a bug with heredoc inside of an array inside of a function call

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -258,7 +258,9 @@ function docShouldHaveTrailingNewline(path) {
   }
 
   if (
-    (parentParent && ["call", "new", "echo"].includes(parentParent.kind)) ||
+    (parentParent &&
+      ["call", "new", "echo"].includes(parentParent.kind) &&
+      parent.kind !== "call") ||
     parent.kind === "parameter"
   ) {
     const lastIndex = parentParent.arguments.length - 1;

--- a/src/util.js
+++ b/src/util.js
@@ -260,7 +260,7 @@ function docShouldHaveTrailingNewline(path) {
   if (
     (parentParent &&
       ["call", "new", "echo"].includes(parentParent.kind) &&
-      parent.kind !== "call") ||
+      !["call", "array"].includes(parent.kind)) ||
     parent.kind === "parameter"
   ) {
     const lastIndex = parentParent.arguments.length - 1;

--- a/tests/nowdoc/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/nowdoc/__snapshots__/jsfmt.spec.js.snap
@@ -62,6 +62,16 @@ foo
 END
 , true));
 
+$str = array(array(<<<END
+foo
+END
+, true));
+
+$str = array(call(<<<END
+foo
+END
+, true));
+
 function foo($a = 1, $b = <<<'EOD'
 Example of string
 spanning multiple lines
@@ -1009,6 +1019,26 @@ END
     ,
     true
 ));
+
+$str = array(
+    array(
+        <<<END
+foo
+END
+        ,
+        true
+    )
+);
+
+$str = array(
+    call(
+        <<<END
+foo
+END
+        ,
+        true
+    )
+);
 
 function foo(
     $a = 1,

--- a/tests/nowdoc/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/nowdoc/__snapshots__/jsfmt.spec.js.snap
@@ -57,6 +57,11 @@ foo
 END
 , true));
 
+$str = call(array(<<<END
+foo
+END
+, true));
+
 function foo($a = 1, $b = <<<'EOD'
 Example of string
 spanning multiple lines
@@ -996,6 +1001,14 @@ END
         true
     )
 );
+
+$str = call(array(
+    <<<END
+foo
+END
+    ,
+    true
+));
 
 function foo(
     $a = 1,

--- a/tests/nowdoc/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/nowdoc/__snapshots__/jsfmt.spec.js.snap
@@ -52,6 +52,11 @@ foo
 EOD
 , true);
 
+$str = sprintf(sprintf(<<<END
+foo
+END
+, true));
+
 function foo($a = 1, $b = <<<'EOD'
 Example of string
 spanning multiple lines
@@ -980,6 +985,16 @@ foo
 EOD
     ,
     true
+);
+
+$str = sprintf(
+    sprintf(
+        <<<END
+foo
+END
+        ,
+        true
+    )
 );
 
 function foo(

--- a/tests/nowdoc/nowdoc.php
+++ b/tests/nowdoc/nowdoc.php
@@ -44,6 +44,11 @@ foo
 EOD
 , true);
 
+$str = sprintf(sprintf(<<<END
+foo
+END
+, true));
+
 function foo($a = 1, $b = <<<'EOD'
 Example of string
 spanning multiple lines

--- a/tests/nowdoc/nowdoc.php
+++ b/tests/nowdoc/nowdoc.php
@@ -54,6 +54,16 @@ foo
 END
 , true));
 
+$str = array(array(<<<END
+foo
+END
+, true));
+
+$str = array(call(<<<END
+foo
+END
+, true));
+
 function foo($a = 1, $b = <<<'EOD'
 Example of string
 spanning multiple lines

--- a/tests/nowdoc/nowdoc.php
+++ b/tests/nowdoc/nowdoc.php
@@ -49,6 +49,11 @@ foo
 END
 , true));
 
+$str = call(array(<<<END
+foo
+END
+, true));
+
 function foo($a = 1, $b = <<<'EOD'
 Example of string
 spanning multiple lines


### PR DESCRIPTION
There is a bug with heredoc inside of an array inside of a function call formatting to a syntax error.

Input:
```
$str = call(array(<<<END
foo
END
, true));
```

prettier php output with syntax error:
```
$str = call(array(
    <<<END
foo
END, 
    true
));
```

this pr output:
```
$str = call(array(
    <<<END
foo
END
    , 
    true
));
```
