### PR TITLE
test: fix invalid test

### DIFF
--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -613,9 +613,9 @@ $var = $a/* Comment */['test'];
 $var = $a /* Comment */->/* Comment */ bar();
 $var = $a /* Comment */::/* Comment */ bar();
 
-$a /* Comment*/./*Comment*/ bar/* Comment */;
+$a /* Comment*/->/*Comment*/ bar/* Comment */;
 $a/* Comment */['test'];
-$a /* Comment */./* Comment */ bar();
+$a /* Comment */->/* Comment */ bar();
 $a /* Comment */::/* Comment */ bar();
 
 =====================================output=====================================
@@ -638,9 +638,10 @@ $var = $a /* Comment */
 $var = $a /* Comment */
     ::/* Comment */ bar();
 
-$a /* Comment*/ . /*Comment*/ bar /* Comment */;
+$a /* Comment*/->/*Comment*/ bar /* Comment */;
 $a /* Comment */['test'];
-$a /* Comment */ . /* Comment */ bar();
+$a /* Comment */
+    ->/* Comment */ bar();
 $a /* Comment */
     ::/* Comment */ bar();
 

--- a/tests/comments/chains.php
+++ b/tests/comments/chains.php
@@ -15,7 +15,7 @@ $var = $a/* Comment */['test'];
 $var = $a /* Comment */->/* Comment */ bar();
 $var = $a /* Comment */::/* Comment */ bar();
 
-$a /* Comment*/./*Comment*/ bar/* Comment */;
+$a /* Comment*/->/*Comment*/ bar/* Comment */;
 $a/* Comment */['test'];
-$a /* Comment */./* Comment */ bar();
+$a /* Comment */->/* Comment */ bar();
 $a /* Comment */::/* Comment */ bar();


### PR DESCRIPTION
maybe we just copy tests from js, because `.` in JS is not same in PHP :smile: 