### PR TITLE
fix: flexible heredoc/nowdoc syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "linguist-languages": "^7.5.1",
     "mem": "^6.0.1",
-    "php-parser": "glayzzle/php-parser#ce0ae3c020b8c81039294b92f882eeb54fd843b5"
+    "php-parser": "glayzzle/php-parser#42c28cdd8e8dbc3423d72d49bd86db8249e01fe5"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.7.5",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "linguist-languages": "^7.5.1",
     "mem": "^6.0.1",
-    "php-parser": "glayzzle/php-parser#8ddd319ff32fe56afc3fdb0bd82a65ad0943c747"
+    "php-parser": "glayzzle/php-parser#ce0ae3c020b8c81039294b92f882eeb54fd843b5"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.7.5",

--- a/tests/nowdoc/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/nowdoc/__snapshots__/jsfmt.spec.js.snap
@@ -946,11 +946,11 @@ string
 EOD
 ];
 
-$newInPhp73 = <<<'EOD'
-              Example of string
-              spanning multiple lines
-              using nowdoc syntax.
-              EOD;
+$php73FlexibleNowdoc = <<<'EOD'
+      Example of string
+      spanning multiple lines
+      using nowdoc syntax.
+      EOD;
 
 =====================================output=====================================
 <?php
@@ -1972,7 +1972,7 @@ string
 EOD
 ];
 
-$newInPhp73 = <<<'EOD'
+$php73FlexibleNowdoc = <<<'EOD'
 Example of string
 spanning multiple lines
 using nowdoc syntax.

--- a/tests/nowdoc/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/nowdoc/__snapshots__/jsfmt.spec.js.snap
@@ -946,6 +946,12 @@ string
 EOD
 ];
 
+$newInPhp73 = <<<'EOD'
+              Example of string
+              spanning multiple lines
+              using nowdoc syntax.
+              EOD;
+
 =====================================output=====================================
 <?php
 
@@ -1965,6 +1971,13 @@ string
 string
 EOD
 ];
+
+$newInPhp73 = <<<'EOD'
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+
+EOD;
 
 ================================================================================
 `;

--- a/tests/nowdoc/nowdoc.php
+++ b/tests/nowdoc/nowdoc.php
@@ -938,8 +938,8 @@ string
 EOD
 ];
 
-$newInPhp73 = <<<'EOD'
-              Example of string
-              spanning multiple lines
-              using nowdoc syntax.
-              EOD;
+$php73FlexibleNowdoc = <<<'EOD'
+      Example of string
+      spanning multiple lines
+      using nowdoc syntax.
+      EOD;

--- a/tests/nowdoc/nowdoc.php
+++ b/tests/nowdoc/nowdoc.php
@@ -937,3 +937,9 @@ string
 string
 EOD
 ];
+
+$newInPhp73 = <<<'EOD'
+              Example of string
+              spanning multiple lines
+              using nowdoc syntax.
+              EOD;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4046,9 +4046,9 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-php-parser@glayzzle/php-parser#ce0ae3c020b8c81039294b92f882eeb54fd843b5:
+php-parser@glayzzle/php-parser#42c28cdd8e8dbc3423d72d49bd86db8249e01fe5:
   version "3.0.0-prerelease.9"
-  resolved "https://codeload.github.com/glayzzle/php-parser/tar.gz/ce0ae3c020b8c81039294b92f882eeb54fd843b5"
+  resolved "https://codeload.github.com/glayzzle/php-parser/tar.gz/42c28cdd8e8dbc3423d72d49bd86db8249e01fe5"
 
 pify@^2.0.0:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4046,9 +4046,9 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-php-parser@glayzzle/php-parser#8ddd319ff32fe56afc3fdb0bd82a65ad0943c747:
+php-parser@glayzzle/php-parser#ce0ae3c020b8c81039294b92f882eeb54fd843b5:
   version "3.0.0-prerelease.9"
-  resolved "https://codeload.github.com/glayzzle/php-parser/tar.gz/8ddd319ff32fe56afc3fdb0bd82a65ad0943c747"
+  resolved "https://codeload.github.com/glayzzle/php-parser/tar.gz/ce0ae3c020b8c81039294b92f882eeb54fd843b5"
 
 pify@^2.0.0:
   version "2.3.0"


### PR DESCRIPTION
This is just updating the parser - how we want to support the flexible heredoc/nowdoc feature introduced in PHP 7.3 still needs to be discussed.