### PR TITLE
feat: update parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "linguist-languages": "^7.5.1",
     "mem": "^6.0.1",
-    "php-parser": "glayzzle/php-parser#42c28cdd8e8dbc3423d72d49bd86db8249e01fe5"
+    "php-parser": "glayzzle/php-parser#917acf310a832302da0309f826592fd7c49e7520"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.7.5",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "linguist-languages": "^7.5.1",
     "mem": "^6.0.1",
-    "php-parser": "glayzzle/php-parser#917acf310a832302da0309f826592fd7c49e7520"
+    "php-parser": "glayzzle/php-parser#b3b2055c24bafc1abd66cb9612b93862db4abd22"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.7.5",

--- a/src/printer.js
+++ b/src/printer.js
@@ -1502,7 +1502,7 @@ function printAssignmentRight(
     return indent(concat([hardline, ref, printedRight]));
   }
 
-  const pureRightNode = rightNode.kind === "cast" ? rightNode.what : rightNode;
+  const pureRightNode = rightNode.kind === "cast" ? rightNode.expr : rightNode;
 
   const canBreak =
     (pureRightNode.kind === "bin" &&
@@ -2505,16 +2505,21 @@ function printNode(path, options, print) {
         { shouldBreak }
       );
     }
-    case "entry":
-      return printAssignment(
-        node.key,
-        path.call(print, "key"),
-        " =>",
-        node.value,
-        path.call(print, "value"),
-        false,
-        options
-      );
+    case "entry": {
+      const ref = node.byRef ? "&" : "";
+      const unpack = node.unpack ? "..." : "";
+      return node.key
+        ? printAssignment(
+            node.key,
+            path.call(print, "key"),
+            " =>",
+            node.value,
+            path.call(print, "value"),
+            false,
+            options
+          )
+        : concat([ref, unpack, path.call(print, "value")]);
+    }
     case "yield": {
       const printedKeyAndValue = concat([
         node.key ? concat([path.call(print, "key"), " => "]) : "",
@@ -2547,9 +2552,9 @@ function printNode(path, options, print) {
         "(",
         node.type,
         ") ",
-        node.what.comments
-          ? indent(path.call(print, "what"))
-          : path.call(print, "what")
+        node.expr.comments
+          ? indent(path.call(print, "expr"))
+          : path.call(print, "expr")
       ]);
     case "assignref":
     case "assign": {

--- a/tests/array/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/array/__snapshots__/jsfmt.spec.js.snap
@@ -534,6 +534,14 @@ $o = [
         $obj->props->cardType === $AwesomizerCardEnum->SEEFIRST,
 ];
 
+// spread
+$var = ['banana', 'orange', ...$parts, 'watermelon'];
+$var = [...$arr1];
+$var = [0, ...$arr1];
+$var = array(...$arr1, ...$arr2, 111);
+$var = [...$arr1, ...$arr1];
+$var = [...getArr(), 'c'];
+$var = [...new ArrayIterator(['a', 'b', 'c'])];
 
 =====================================output=====================================
 <?php
@@ -842,6 +850,15 @@ $o = [
     "somethingThatsAReallyLongPropName" =>
         $obj->props->cardType === $AwesomizerCardEnum->SEEFIRST
 ];
+
+// spread
+$var = ['banana', 'orange', ...$parts, 'watermelon'];
+$var = [...$arr1];
+$var = [0, ...$arr1];
+$var = array(...$arr1, ...$arr2, 111);
+$var = [...$arr1, ...$arr1];
+$var = [...getArr(), 'c'];
+$var = [...new ArrayIterator(['a', 'b', 'c'])];
 
 ================================================================================
 `;

--- a/tests/array/arrays.php
+++ b/tests/array/arrays.php
@@ -526,3 +526,11 @@ $o = [
         $obj->props->cardType === $AwesomizerCardEnum->SEEFIRST,
 ];
 
+// spread
+$var = ['banana', 'orange', ...$parts, 'watermelon'];
+$var = [...$arr1];
+$var = [0, ...$arr1];
+$var = array(...$arr1, ...$arr2, 111);
+$var = [...$arr1, ...$arr1];
+$var = [...getArr(), 'c'];
+$var = [...new ArrayIterator(['a', 'b', 'c'])];

--- a/tests/nowdoc/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/nowdoc/__snapshots__/jsfmt.spec.js.snap
@@ -946,11 +946,19 @@ string
 EOD
 ];
 
+<<<<<<< HEAD
 $php73FlexibleNowdoc = <<<'EOD'
       Example of string
       spanning multiple lines
       using nowdoc syntax.
       EOD;
+=======
+$newInPhp73 = <<<'EOD'
+              Example of string
+              spanning multiple lines
+              using nowdoc syntax.
+              EOD;
+>>>>>>> feat: flexible heredoc/nowdoc syntax
 
 =====================================output=====================================
 <?php
@@ -1972,7 +1980,11 @@ string
 EOD
 ];
 
+<<<<<<< HEAD
 $php73FlexibleNowdoc = <<<'EOD'
+=======
+$newInPhp73 = <<<'EOD'
+>>>>>>> feat: flexible heredoc/nowdoc syntax
 Example of string
 spanning multiple lines
 using nowdoc syntax.

--- a/tests/nowdoc/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/nowdoc/__snapshots__/jsfmt.spec.js.snap
@@ -946,19 +946,11 @@ string
 EOD
 ];
 
-<<<<<<< HEAD
 $php73FlexibleNowdoc = <<<'EOD'
       Example of string
       spanning multiple lines
       using nowdoc syntax.
       EOD;
-=======
-$newInPhp73 = <<<'EOD'
-              Example of string
-              spanning multiple lines
-              using nowdoc syntax.
-              EOD;
->>>>>>> feat: flexible heredoc/nowdoc syntax
 
 =====================================output=====================================
 <?php
@@ -1980,11 +1972,7 @@ string
 EOD
 ];
 
-<<<<<<< HEAD
 $php73FlexibleNowdoc = <<<'EOD'
-=======
-$newInPhp73 = <<<'EOD'
->>>>>>> feat: flexible heredoc/nowdoc syntax
 Example of string
 spanning multiple lines
 using nowdoc syntax.

--- a/tests/parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/parens/__snapshots__/jsfmt.spec.js.snap
@@ -712,6 +712,8 @@ $var = (@foo() || @foo());
 @$i / 0;
 @($i) / 0;
 
+$var = "a" . (@$b ? 'bar' : "baz");
+
 $a = (false && foo());
 $b = (true  || foo());
 $c = (false and foo());
@@ -1091,6 +1093,8 @@ $var = @foo() || @foo();
 
 @$i / 0;
 @$i / 0;
+
+$var = "a" . (@$b ? 'bar' : "baz");
 
 $a = false && foo();
 $b = true || foo();

--- a/tests/parens/bin.php
+++ b/tests/parens/bin.php
@@ -338,6 +338,8 @@ $var = (@foo() || @foo());
 @$i / 0;
 @($i) / 0;
 
+$var = "a" . (@$b ? 'bar' : "baz");
+
 $a = (false && foo());
 $b = (true  || foo());
 $c = (false and foo());

--- a/yarn.lock
+++ b/yarn.lock
@@ -4046,9 +4046,9 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-php-parser@glayzzle/php-parser#917acf310a832302da0309f826592fd7c49e7520:
+php-parser@glayzzle/php-parser#b3b2055c24bafc1abd66cb9612b93862db4abd22:
   version "3.0.0-prerelease.9"
-  resolved "https://codeload.github.com/glayzzle/php-parser/tar.gz/917acf310a832302da0309f826592fd7c49e7520"
+  resolved "https://codeload.github.com/glayzzle/php-parser/tar.gz/b3b2055c24bafc1abd66cb9612b93862db4abd22"
 
 pify@^2.0.0:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4046,9 +4046,9 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-php-parser@glayzzle/php-parser#42c28cdd8e8dbc3423d72d49bd86db8249e01fe5:
+php-parser@glayzzle/php-parser#917acf310a832302da0309f826592fd7c49e7520:
   version "3.0.0-prerelease.9"
-  resolved "https://codeload.github.com/glayzzle/php-parser/tar.gz/42c28cdd8e8dbc3423d72d49bd86db8249e01fe5"
+  resolved "https://codeload.github.com/glayzzle/php-parser/tar.gz/917acf310a832302da0309f826592fd7c49e7520"
 
 pify@^2.0.0:
   version "2.3.0"


### PR DESCRIPTION
This adds support for the spread operator for arrays (PHP 7.4) and fixes
an issue with silent / retif precedence.

Fixes #1009