### PR TITLE
chore: update parser to add numeric literal separator support

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "linguist-languages": "^7.5.1",
     "mem": "^6.0.1",
-    "php-parser": "glayzzle/php-parser#6e372bac9497c3d2576d9dc22c3ca1c7946a78d2"
+    "php-parser": "glayzzle/php-parser#5813bde750922158f463ea64f597a86d1f1369bd"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.7.5",

--- a/tests/number/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/number/__snapshots__/jsfmt.spec.js.snap
@@ -104,6 +104,17 @@ $a = 1.0;
 // 1. === 1.0, but 1. !== 1
 $a = 1.;
 $a = 1;
+
+// numeric literal separator, added in 7.4
+$threshold = 1_000_000_000;
+$testValue = 107_925_284.88;
+$discount = 135_00;
+6.674_083e-11; // float
+299_792_458;   // decimal
+0xCAFE_F00D;   // hexadecimal
+0b0101_1111;   // binary
+0137_041;      // octal
+
 =====================================output=====================================
 <?php
 $a = 0;
@@ -203,6 +214,16 @@ $a = 1.0;
 // 1. === 1.0, but 1. !== 1
 $a = 1.;
 $a = 1;
+
+// numeric literal separator, added in 7.4
+$threshold = 1_000_000_000;
+$testValue = 107_925_284.88;
+$discount = 135_00;
+6.674_083e-11; // float
+299_792_458; // decimal
+0xcafe_f00d; // hexadecimal
+0b0101_1111; // binary
+0137_041; // octal
 
 ================================================================================
 `;

--- a/tests/number/number.php
+++ b/tests/number/number.php
@@ -96,3 +96,13 @@ $a = 1.0;
 // 1. === 1.0, but 1. !== 1
 $a = 1.;
 $a = 1;
+
+// numeric literal separator, added in 7.4
+$threshold = 1_000_000_000;
+$testValue = 107_925_284.88;
+$discount = 135_00;
+6.674_083e-11; // float
+299_792_458;   // decimal
+0xCAFE_F00D;   // hexadecimal
+0b0101_1111;   // binary
+0137_041;      // octal

--- a/yarn.lock
+++ b/yarn.lock
@@ -4089,9 +4089,9 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-php-parser@glayzzle/php-parser#6e372bac9497c3d2576d9dc22c3ca1c7946a78d2:
+php-parser@glayzzle/php-parser#5813bde750922158f463ea64f597a86d1f1369bd:
   version "3.0.0-prerelease.9"
-  resolved "https://codeload.github.com/glayzzle/php-parser/tar.gz/6e372bac9497c3d2576d9dc22c3ca1c7946a78d2"
+  resolved "https://codeload.github.com/glayzzle/php-parser/tar.gz/5813bde750922158f463ea64f597a86d1f1369bd"
 
 pify@^2.0.0:
   version "2.3.0"


### PR DESCRIPTION
Related to https://github.com/prettier/plugin-php/issues/854