### PR TITLE
fix: remove broken handling of prettier-ignore-start and -end, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,40 @@ Prettier for PHP supports the following options:
 | `requirePragma`    | `false`   | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#require-pragma))                                                                                                                                                                                                                                                                                    |
 | `insertPragma`     | `false`   | Same as in Prettier ([see prettier docs](https://prettier.io/docs/en/options.html#insert-pragma))                                                                                                                                                                                                                                                                                     |
 
+## Ignoring code
+
+A comment `// prettier-ignore` will exclude the next node in the abstract syntax tree from formatting.
+
+For example:
+
+```php
+matrix(
+  1, 0, 0,
+  0, 1, 0,
+  0, 0, 1
+);
+
+// prettier-ignore
+matrix(
+  1, 0, 0,
+  0, 1, 0,
+  0, 0, 1
+);
+```
+
+will be transformed to
+
+```php
+matrix(1, 0, 0, 0, 1, 0, 0, 0, 1);
+
+// prettier-ignore
+matrix(
+  1, 0, 0,
+  0, 1, 0,
+  0, 0, 1
+)
+```
+
 ## Editor integration
 
 ### Atom

--- a/src/index.js
+++ b/src/index.js
@@ -117,11 +117,15 @@ const printers = {
     },
     hasPrettierIgnore(path) {
       const node = path.getNode();
+      const isSimpleIgnore = comment =>
+        comment.value.includes("prettier-ignore") &&
+        !comment.value.includes("prettier-ignore-start") &&
+        !comment.value.includes("prettier-ignore-end");
       return (
         node &&
         node.comments &&
         node.comments.length > 0 &&
-        node.comments.some(comment => comment.value.includes("prettier-ignore"))
+        node.comments.some(isSimpleIgnore)
       );
     }
   }

--- a/tests/ignore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ignore/__snapshots__/jsfmt.spec.js.snap
@@ -34,6 +34,11 @@ function Foo ($veryLongVeryLongVeryLongVeryLongVeryLongVeryLongVeryLong) { retur
                        ]
 ];}
 
+
+// prettier-ignore-start
+$info =    "prettier-ignore-start and -end is currently not supported"  ;
+// prettier-ignore-end
+
 =====================================output=====================================
 <?php
 // prettier-ignore
@@ -62,6 +67,10 @@ function Foo ($veryLongVeryLongVeryLongVeryLongVeryLongVeryLongVeryLong) { retur
                 "php"
                        ]
 ];}
+
+// prettier-ignore-start
+$info = "prettier-ignore-start and -end is currently not supported";
+// prettier-ignore-end
 
 ================================================================================
 `;

--- a/tests/ignore/ignore.php
+++ b/tests/ignore/ignore.php
@@ -25,3 +25,8 @@ function Foo ($veryLongVeryLongVeryLongVeryLongVeryLongVeryLongVeryLong) { retur
                 "php"
                        ]
 ];}
+
+
+// prettier-ignore-start
+$info =    "prettier-ignore-start and -end is currently not supported"  ;
+// prettier-ignore-end


### PR DESCRIPTION
Without this, `prettier-ignore-start`  is interpreted just like `prettier-ignore`:
In:
```php
// prettier-ignore-start
$foo     = "bar";
$foo     = "bar";
$foo     = "bar";
// prettier-ignore-end
```
Out:
```php
// prettier-ignore-start
$foo     = "bar";
$foo = "bar";
$foo = "bar";
// prettier-ignore-end
```