### PR TITLE
Support static & return-typed arrow functions

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1724,6 +1724,9 @@ function printNode(path, options, print) {
         node.isStatic ? "static " : "",
         "fn",
         printArgumentsList(path, options, print),
+        node.type
+          ? concat([": ", node.nullable ? "?" : "", path.call(print, "type")])
+          : "",
         " => ",
         path.call(print, "body"),
       ]);

--- a/src/printer.js
+++ b/src/printer.js
@@ -1721,6 +1721,7 @@ function printNode(path, options, print) {
       return printFunction(path, options, print);
     case "arrowfunc":
       return concat([
+        node.isStatic ? "static " : "",
         "fn",
         printArgumentsList(path, options, print),
         " => ",

--- a/tests/arrowfunc/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/arrowfunc/__snapshots__/jsfmt.spec.js.snap
@@ -11,6 +11,7 @@ $var = fn() => "something";
 $var = fn($arg) =>  "something";
 $var = fn(&$arg) => "something";
 $var = fn($arg, $arg, $arg) => "something";
+$var = static fn($arg, $arg, $arg) => "something";
 // $var = fn(): ?string => "something";
 
 call(fn($arg) => $arg);
@@ -21,6 +22,7 @@ $var = fn() => "something";
 $var = fn($arg) => "something";
 $var = fn(&$arg) => "something";
 $var = fn($arg, $arg, $arg) => "something";
+$var = static fn($arg, $arg, $arg) => "something";
 // $var = fn(): ?string => "something";
 
 call(fn($arg) => $arg);

--- a/tests/arrowfunc/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/arrowfunc/__snapshots__/jsfmt.spec.js.snap
@@ -11,6 +11,8 @@ $var = fn() => "something";
 $var = fn($arg) =>  "something";
 $var = fn(&$arg) => "something";
 $var = fn($arg, $arg, $arg) => "something";
+$var = fn($arg, $arg, $arg): string => "something";
+$var = fn($arg, $arg, $arg): ?string => "something";
 $var = static fn($arg, $arg, $arg) => "something";
 // $var = fn(): ?string => "something";
 
@@ -22,6 +24,8 @@ $var = fn() => "something";
 $var = fn($arg) => "something";
 $var = fn(&$arg) => "something";
 $var = fn($arg, $arg, $arg) => "something";
+$var = fn($arg, $arg, $arg): string => "something";
+$var = fn($arg, $arg, $arg): ?string => "something";
 $var = static fn($arg, $arg, $arg) => "something";
 // $var = fn(): ?string => "something";
 

--- a/tests/arrowfunc/arrowfunc.php
+++ b/tests/arrowfunc/arrowfunc.php
@@ -3,6 +3,8 @@ $var = fn() => "something";
 $var = fn($arg) =>  "something";
 $var = fn(&$arg) => "something";
 $var = fn($arg, $arg, $arg) => "something";
+$var = fn($arg, $arg, $arg): string => "something";
+$var = fn($arg, $arg, $arg): ?string => "something";
 $var = static fn($arg, $arg, $arg) => "something";
 // $var = fn(): ?string => "something";
 

--- a/tests/arrowfunc/arrowfunc.php
+++ b/tests/arrowfunc/arrowfunc.php
@@ -3,6 +3,7 @@ $var = fn() => "something";
 $var = fn($arg) =>  "something";
 $var = fn(&$arg) => "something";
 $var = fn($arg, $arg, $arg) => "something";
+$var = static fn($arg, $arg, $arg) => "something";
 // $var = fn(): ?string => "something";
 
 call(fn($arg) => $arg);


### PR DESCRIPTION
Not that commonly used but [static arrow functions are supported](https://wiki.php.net/rfc/arrow_functions_v2#this_binding_and_static_arrow_functions). Prettier was stripping the static declaration, so this PR preserves it if set. It also adds support for declared return types.