### PR TITLE
feat: update chain breaking heuristic

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -404,9 +404,13 @@ function printMemberChain(path, options, print) {
       const firstNode = groups[0][0].node;
 
       return (
-        (firstNode.kind === "variable" && firstNode.name === "this") ||
+        (firstNode.kind === "variable" && (firstNode.name === "this" || isShort(firstNode.name))) ||
         isReferenceLikeNode(firstNode)
       );
+    }
+
+    function isShort(name) {
+      return name.length <= options.tabWidth;
     }
 
     const lastNode = getLast(groups[0]).node;

--- a/src/printer.js
+++ b/src/printer.js
@@ -395,6 +395,12 @@ function printMemberChain(path, options, print) {
   //    $foo->Data['key']("foo")
   //      ->method();
   //
+  // 3. expression statements with variable names shorter than the tab width
+  //
+  // Example:
+  // $foo->bar()
+  //     ->baz()
+  //     ->buzz()
 
   function shouldNotWrap(groups) {
     const hasComputed =
@@ -404,13 +410,15 @@ function printMemberChain(path, options, print) {
       const firstNode = groups[0][0].node;
 
       return (
-        (firstNode.kind === "variable" && (firstNode.name === "this" || isShort(firstNode.name))) ||
+        (firstNode.kind === "variable" &&
+          (firstNode.name === "this" ||
+            (isExpressionStatement && isShort(firstNode.name)))) ||
         isReferenceLikeNode(firstNode)
       );
     }
 
     function isShort(name) {
-      return name.length <= options.tabWidth;
+      return name.length < options.tabWidth;
     }
 
     const lastNode = getLast(groups[0]).node;
@@ -423,6 +431,8 @@ function printMemberChain(path, options, print) {
     );
   }
 
+  const isExpressionStatement =
+    path.getParentNode().kind === "expressionstatement";
   const shouldMerge =
     groups.length >= 2 && !groups[1][0].node.comments && shouldNotWrap(groups);
 

--- a/tests/call/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/call/__snapshots__/jsfmt.spec.js.snap
@@ -602,23 +602,21 @@ string
 string
 string');
 
-$a
-    ->call(
-        $a,
-        '
+$a->call(
+    $a,
+    '
 string
 string
 string',
-        $c
-    )
-    ->call(
-        $a,
-        '
+    $c
+)->call(
+    $a,
+    '
 string
 string
 string',
-        $c
-    );
+    $c
+);
 
 call("string $var string");
 call("string $var string");

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -703,10 +703,8 @@ $var = $a /* Comment */
 
 $a /* Comment*/->/*Comment*/ bar /* Comment */;
 $a /* Comment */['test'];
-$a /* Comment */
-    ->/* Comment */ bar();
-$a /* Comment */
-    ::/* Comment */ bar();
+$a /* Comment */->/* Comment */ bar();
+$a /* Comment */::/* Comment */ bar();
 
 ================================================================================
 `;

--- a/tests/member_chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/member_chain/__snapshots__/jsfmt.spec.js.snap
@@ -372,6 +372,10 @@ $a->b->a();
 $a->b()->c()->d();
 $a->b->c->d;
 
+$that->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\\Bar\\Baz' ), $this->app['foo.bar.baz']->getEmail())->looooooooooooooooooong();
+$this->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\\Bar\\Baz' ), $this->app['foo.bar.baz']->getEmail())->once();
+$a->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\\Bar\\Baz' ), $this->app['foo.bar.baz']->getEmail())->once();
+
 $this->loooooooooooong->lookup = (int) $this->getRequest()->getParam(
     'some-param'
 );
@@ -473,6 +477,17 @@ $a
     ->c()
     ->d();
 $a->b->c->d;
+
+$that
+    ->shouldReceive('signUp')
+    ->with(anInstanceOf('Foo\\Bar\\Baz'), $this->app['foo.bar.baz']->getEmail())
+    ->looooooooooooooooooong();
+$this->shouldReceive('signUp')
+    ->with(anInstanceOf('Foo\\Bar\\Baz'), $this->app['foo.bar.baz']->getEmail())
+    ->once();
+$a->shouldReceive('signUp')
+    ->with(anInstanceOf('Foo\\Bar\\Baz'), $this->app['foo.bar.baz']->getEmail())
+    ->once();
 
 $this->loooooooooooong->lookup = (int) $this->getRequest()->getParam(
     'some-param'

--- a/tests/member_chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/member_chain/__snapshots__/jsfmt.spec.js.snap
@@ -372,9 +372,13 @@ $a->b->a();
 $a->b()->c()->d();
 $a->b->c->d;
 
-$that->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\\Bar\\Baz' ), $this->app['foo.bar.baz']->getEmail())->looooooooooooooooooong();
-$this->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\\Bar\\Baz' ), $this->app['foo.bar.baz']->getEmail())->once();
-$a->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\\Bar\\Baz' ), $this->app['foo.bar.baz']->getEmail())->once();
+// should inline
+$t->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\\\\Bar\\\\Baz' ), $this->app['foo.bar.baz']->getEmail())->once();
+$te->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\\\\Bar\\\\Baz' ), $this->app['foo.bar.baz']->getEmail())->once();
+$tes->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\\\\Bar\\\\Baz' ), $this->app['foo.bar.baz']->getEmail())->once();
+// should break
+$test->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\\\\Bar\\\\Baz' ), $this->app['foo.bar.baz']->getEmail())->once();
+$a = $t->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\\\\Bar\\\\Baz' ), $this->app['foo.bar.baz']->getEmail())->once();
 
 $this->loooooooooooong->lookup = (int) $this->getRequest()->getParam(
     'some-param'
@@ -472,21 +476,29 @@ $a->a()->b();
 $a->a()->b();
 $a->a()->b;
 $a->b->a();
-$a
-    ->b()
+$a->b()
     ->c()
     ->d();
 $a->b->c->d;
 
-$that
-    ->shouldReceive('signUp')
-    ->with(anInstanceOf('Foo\\Bar\\Baz'), $this->app['foo.bar.baz']->getEmail())
-    ->looooooooooooooooooong();
-$this->shouldReceive('signUp')
-    ->with(anInstanceOf('Foo\\Bar\\Baz'), $this->app['foo.bar.baz']->getEmail())
+// should inline
+$t->shouldReceive('signUp')
+    ->with(anInstanceOf('Foo\\\\Bar\\\\Baz'), $this->app['foo.bar.baz']->getEmail())
     ->once();
-$a->shouldReceive('signUp')
-    ->with(anInstanceOf('Foo\\Bar\\Baz'), $this->app['foo.bar.baz']->getEmail())
+$te->shouldReceive('signUp')
+    ->with(anInstanceOf('Foo\\\\Bar\\\\Baz'), $this->app['foo.bar.baz']->getEmail())
+    ->once();
+$tes->shouldReceive('signUp')
+    ->with(anInstanceOf('Foo\\\\Bar\\\\Baz'), $this->app['foo.bar.baz']->getEmail())
+    ->once();
+// should break
+$test
+    ->shouldReceive('signUp')
+    ->with(anInstanceOf('Foo\\\\Bar\\\\Baz'), $this->app['foo.bar.baz']->getEmail())
+    ->once();
+$a = $t
+    ->shouldReceive('signUp')
+    ->with(anInstanceOf('Foo\\\\Bar\\\\Baz'), $this->app['foo.bar.baz']->getEmail())
     ->once();
 
 $this->loooooooooooong->lookup = (int) $this->getRequest()->getParam(

--- a/tests/member_chain/member_chain.php
+++ b/tests/member_chain/member_chain.php
@@ -33,9 +33,13 @@ $a->b->a();
 $a->b()->c()->d();
 $a->b->c->d;
 
-$that->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\Bar\Baz' ), $this->app['foo.bar.baz']->getEmail())->looooooooooooooooooong();
-$this->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\Bar\Baz' ), $this->app['foo.bar.baz']->getEmail())->once();
-$a->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\Bar\Baz' ), $this->app['foo.bar.baz']->getEmail())->once();
+// should inline
+$t->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\\Bar\\Baz' ), $this->app['foo.bar.baz']->getEmail())->once();
+$te->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\\Bar\\Baz' ), $this->app['foo.bar.baz']->getEmail())->once();
+$tes->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\\Bar\\Baz' ), $this->app['foo.bar.baz']->getEmail())->once();
+// should break
+$test->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\\Bar\\Baz' ), $this->app['foo.bar.baz']->getEmail())->once();
+$a = $t->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\\Bar\\Baz' ), $this->app['foo.bar.baz']->getEmail())->once();
 
 $this->loooooooooooong->lookup = (int) $this->getRequest()->getParam(
     'some-param'

--- a/tests/member_chain/member_chain.php
+++ b/tests/member_chain/member_chain.php
@@ -33,6 +33,10 @@ $a->b->a();
 $a->b()->c()->d();
 $a->b->c->d;
 
+$that->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\Bar\Baz' ), $this->app['foo.bar.baz']->getEmail())->looooooooooooooooooong();
+$this->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\Bar\Baz' ), $this->app['foo.bar.baz']->getEmail())->once();
+$a->shouldReceive( 'signUp' )->with( anInstanceOf( 'Foo\Bar\Baz' ), $this->app['foo.bar.baz']->getEmail())->once();
+
 $this->loooooooooooong->lookup = (int) $this->getRequest()->getParam(
     'some-param'
 );


### PR DESCRIPTION
As suggested here https://github.com/prettier/plugin-php/issues/1386#issuecomment-627439042, I've committed as a pull request my starting point to implement the same heuristic as Prettier js for chain breaking. In particular, prettier PHP formats as follows:
```php
$db
    ->setQuery()
    ->setValue()
    ->execute();
```
Whereas prettier js has adopted a style of keeping the first call on the same line as the parent when the parent is shorter than the indent size, as follows:
```php
$db->setQuery()
    ->setValue()
    ->execute();
```
I briefly started trying to implement this, and got as far as putting some test data in (probably the most valuable part of this PR), but I don't know enough about prettier to figure out whether the parent is at the beginning of a line. Without that, the change would cause a lot of things to wrap that we don't want to wrap, breaking a lot of other tests (as you'll see if you run the tests on this).

It would be good, though, if the project were to get in line with how prettier handles this, i think.