### PR TITLE
PrettierPHPFixer - Use output of exec directly instead of writing temporary file

### DIFF
--- a/docs/recipes/php-cs-fixer/PrettierPHPFixer.php
+++ b/docs/recipes/php-cs-fixer/PrettierPHPFixer.php
@@ -58,37 +58,13 @@ final class PrettierPHPFixer implements FixerInterface {
     }
 
     /**
-     * {@inheritdoc}
+     * @param SplFileInfo $file
+     * @param Tokens      $tokens
      */
-    private function applyFix(SplFileInfo $file, Tokens $tokens) {
-        $tmpFile = $this->getTmpFile($file);
-        exec("yarn exec -- prettier --write $tmpFile");
-
-        $content = file_get_contents($tmpFile);
-        $tokens->setCode($content);
-
-        (new Filesystem())->remove($tmpFile);
-    }
-
-    /**
-     * Create a Temp file with the same content as given file.
-     *
-     * @param SplFileInfo $file file to be copied
-     *
-     * @return string tmp file name
-     */
-    private function getTmpFile(SplFileInfo $file): string {
-        $fileSys = new Filesystem();
-        $tmpFolderPath = __DIR__.DIRECTORY_SEPARATOR.'tmp';
-        $fileSys->mkdir($tmpFolderPath);
-
-        $tmpFileName = str_replace(
-            array(DIRECTORY_SEPARATOR, ':'),
-            '_',
-            $file->getRealPath()
-        );
-        $tmpFilePath = $tmpFolderPath.DIRECTORY_SEPARATOR.'__'.$tmpFileName;
-        $fileSys->copy($file->getRealPath(), $tmpFilePath, true);
-        return $tmpFilePath;
+    private function applyFix(SplFileInfo $file, Tokens $tokens): void
+    {
+        exec("yarn exec -- prettier $file", $prettierOutput);
+        $code = implode(PHP_EOL, $prettierOutput);
+        $tokens->setCode($code);
     }
 }

--- a/docs/recipes/php-cs-fixer/README.md
+++ b/docs/recipes/php-cs-fixer/README.md
@@ -6,7 +6,7 @@
   applied, such that the `php-cs-fixer` user's configurations is respected.
 
 ## Useful Configurations
-  
+
 ### Priority
 
   If you would like `prettier` to execute last, which means you prefer to use
@@ -21,8 +21,8 @@
 
    For example,
    ```diff
-     - exec("yarn exec -- prettier --write $tmpFile");
-     + exec("yarn exec -- prettier --write --brace-style=1tbs $tmpFile");
+     - exec("yarn exec -- prettier $file");
+     + exec("yarn exec -- prettier --brace-style=1tbs $file");
    ```
    will allow you to change the `braceStyle` for this fixer
 


### PR DESCRIPTION
Hey,

Instead of writing a temporary file, Prettier's output can be processed directly if the second parameter of `exec` is set. This simplifies the fixer and should make it a bit more efficient.

I've tested this with a Symfony codebase with around 950 files and everything seemed fine. On my machine with a SSD the change had little impact on performance, but if an HDD is used, it might.

What do you think?