### PR TITLE
Fix indent on multiline string on version >= 7.3

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2793,8 +2793,9 @@ function printNode(path, options, print) {
         const parentParent = path.getParentNode(1);
         let closingTagIndentation = 0;
         const flexible = isMinVersion(options.phpVersion, "7.3");
-        const linebreak = flexible ? hardline : literalline;
+        let linebreak = literalline;
         if (parentParent.type === "heredoc") {
+          linebreak = flexible ? hardline : literalline;
           const lines = parentParent.raw.split(/\r?\n/g);
           closingTagIndentation = lines[lines.length - 1].search(/\S/);
         }

--- a/tests/encapsed/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/encapsed/__snapshots__/jsfmt.spec.js.snap
@@ -466,6 +466,16 @@ function foo() {
         XML;
 }
 
+// Multiline with variable
+function b()
+{
+    $a = "
+        This multiline string
+        should keep it's indent level.
+        Even though it has a variable: $c
+    ";
+}
+
 =====================================output=====================================
 <?php
 $encapsShell = \`a $b\`;
@@ -977,6 +987,16 @@ foo{$bar}bazzzzz
 XML;
 }
 
+// Multiline with variable
+function b()
+{
+    $a = "
+        This multiline string
+        should keep it's indent level.
+        Even though it has a variable: $c
+    ";
+}
+
 ================================================================================
 `;
 
@@ -1445,6 +1465,16 @@ function foo() {
     $xml = <<<XML
         foo{$bar}bazzzzz
         XML;
+}
+
+// Multiline with variable
+function b()
+{
+    $a = "
+        This multiline string
+        should keep it's indent level.
+        Even though it has a variable: $c
+    ";
 }
 
 =====================================output=====================================
@@ -1957,6 +1987,16 @@ function foo()
     $xml = <<<XML
     foo{$bar}bazzzzz
     XML;
+}
+
+// Multiline with variable
+function b()
+{
+    $a = "
+        This multiline string
+        should keep it's indent level.
+        Even though it has a variable: $c
+    ";
 }
 
 ================================================================================

--- a/tests/encapsed/encapsed.php
+++ b/tests/encapsed/encapsed.php
@@ -457,3 +457,13 @@ function foo() {
         foo{$bar}bazzzzz
         XML;
 }
+
+// Multiline with variable
+function b()
+{
+    $a = "
+        This multiline string
+        should keep it's indent level.
+        Even though it has a variable: $c
+    ";
+}


### PR DESCRIPTION
This fixes #1593

Seems like the support of flexible HereDoc accidentally broke multiline string with encapsed variable.