### PR TITLE
Add phpVersion 8.0

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -22,6 +22,7 @@ module.exports = {
       { value: "7.2" },
       { value: "7.3" },
       { value: "7.4" },
+      { value: "8.0" },
     ],
   },
   trailingCommaPHP: {


### PR DESCRIPTION
I know it's not fully supported yet!  However, the actual formatting code uses a minimum check so setting `phpVersion` to `8.0` shouldn't break anything compared to `7.4`.

This would allow me to update my prettier configuration as soon as I migrate PHP versions without waiting for this project and `php-parser` to work y'all's magic!