### PR TITLE
feat(CI) Update NodeJS versions to current stable releases

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node-version: [10.x, 12.x, 13.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Node 13 is no longer supported by the NodeJS Foundation, we should focus on currently supported versions.