### PR TITLE
fix: remove jest config from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,10 +49,5 @@
     "prettier": "prettier --plugin=. --parser=php",
     "build-standalone": "rollup -c build/rollup.config.js",
     "debug": "node --inspect-brk node_modules/.bin/jest --runInBand"
-  },
-  "jest": {
-    "projects": [
-      "<rootDir>/jest.*.config.js"
-    ]
   }
 }


### PR DESCRIPTION
Jest was warning about the config in package.json:
```
Multiple configurations found:
    * /home/christian/dev/plugin-php/jest.config.js
    * `jest` key in /home/christian/dev/plugin-php/package.json

  Implicit config resolution does not allow multiple configuration files.
  Either remove unused config files or select one explicitly with `--config`.
```