### PR TITLE
Fix member chain when nullsafe operator is used

### DIFF
--- a/src/needs-parens.js
+++ b/src/needs-parens.js
@@ -52,6 +52,7 @@ function needsParens(path) {
             (node.type === "+" || node.type === "-")
           );
         case "propertylookup":
+        case "nullsafepropertylookup":
         case "staticlookup":
         case "offsetlookup":
         case "call":
@@ -76,6 +77,7 @@ function needsParens(path) {
           return true;
         case "call":
         case "propertylookup":
+        case "nullsafepropertylookup":
         case "staticlookup":
         case "offsetlookup":
           return name === "what" && parent.what === node;
@@ -121,6 +123,7 @@ function needsParens(path) {
       }
     }
     case "propertylookup":
+    case "nullsafepropertylookup":
     case "staticlookup": {
       switch (parent.kind) {
         case "call":
@@ -138,6 +141,7 @@ function needsParens(path) {
     case "new": {
       switch (parent.kind) {
         case "propertylookup":
+        case "nullsafepropertylookup":
         case "staticlookup":
         case "offsetlookup":
         case "call":
@@ -149,6 +153,7 @@ function needsParens(path) {
     case "yield": {
       switch (parent.kind) {
         case "propertylookup":
+        case "nullsafepropertylookup":
         case "staticlookup":
         case "offsetlookup":
         case "call":
@@ -196,6 +201,7 @@ function needsParens(path) {
 
           return true;
         case "propertylookup":
+        case "nullsafepropertylookup":
         case "staticlookup":
         case "offsetlookup":
         case "call":
@@ -211,6 +217,7 @@ function needsParens(path) {
 
         // https://github.com/prettier/plugin-php/issues/1675
         case "propertylookup":
+        case "nullsafepropertylookup":
           return true;
 
         default:
@@ -225,6 +232,7 @@ function needsParens(path) {
     case "array":
       switch (parent.kind) {
         case "propertylookup":
+        case "nullsafepropertylookup":
         case "staticlookup":
         case "offsetlookup":
         case "call":

--- a/src/printer.js
+++ b/src/printer.js
@@ -288,7 +288,7 @@ function printMemberChain(path, options, print) {
     if (
       printedNodes[i].node.kind === "call" &&
       printedNodes[i - 1] &&
-      ["propertylookup", "staticlookup"].includes(
+      ["propertylookup", "nullsafepropertylookup", "staticlookup"].includes(
         printedNodes[i - 1].node.kind
       ) &&
       printedNodes[i - 1].needsParens
@@ -2822,7 +2822,11 @@ function printNode(path, options, print) {
       const parentParent = path.getParentNode(1);
       const pureParent =
         parent.kind === "cast" && parentParent ? parentParent : parent;
-      const breakLookupNodes = ["propertylookup", "staticlookup"];
+      const breakLookupNodes = [
+        "propertylookup",
+        "nullsafepropertylookup",
+        "staticlookup",
+      ];
       const breakClosingParens = breakLookupNodes.includes(pureParent.kind);
 
       const printedTest = path.call(print, "test");

--- a/src/util.js
+++ b/src/util.js
@@ -485,6 +485,7 @@ function hasTrailingComment(node) {
 function isLookupNode(node) {
   return (
     node.kind === "propertylookup" ||
+    node.kind === "nullsafepropertylookup" ||
     node.kind === "staticlookup" ||
     node.kind === "offsetlookup"
   );

--- a/tests/nullsafepropertylookup/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/nullsafepropertylookup/__snapshots__/jsfmt.spec.js.snap
@@ -26,6 +26,16 @@ $obj?->foo_{'test' . 'bar'};
 // variable with literal with call
 $obj?->\${call()};
 
+// long methods names chaining
+// all nullsafe
+$obj?->aaaaaaaaaaaaaaaaaaaaaaaa()?->ccccccccccccccccccccccccccccc()?->ccccccccccccccccccccc();
+// first nullsafe
+$obj?->aaaaaaaaaaaaaaaaaaaaaaaa()->ccccccccccccccccccccccccccccc()->ccccccccccccccccccccc();
+// middle nullsafe
+$obj->aaaaaaaaaaaaaaaaaaaaaaaa()?->ccccccccccccccccccccccccccccc()->ccccccccccccccccccccc();
+// last nullsafe
+$obj->aaaaaaaaaaaaaaaaaaaaaaaa()->ccccccccccccccccccccccccccccc()?->ccccccccccccccccccccc();
+
 =====================================output=====================================
 <?php
 
@@ -45,6 +55,24 @@ $obj?->{call()};
 $obj?->foo_["test" . "bar"];
 // variable with literal with call
 $obj?->\${call()};
+
+// long methods names chaining
+// all nullsafe
+$obj?->aaaaaaaaaaaaaaaaaaaaaaaa()
+    ?->ccccccccccccccccccccccccccccc()
+    ?->ccccccccccccccccccccc();
+// first nullsafe
+$obj?->aaaaaaaaaaaaaaaaaaaaaaaa()
+    ->ccccccccccccccccccccccccccccc()
+    ->ccccccccccccccccccccc();
+// middle nullsafe
+$obj->aaaaaaaaaaaaaaaaaaaaaaaa()
+    ?->ccccccccccccccccccccccccccccc()
+    ->ccccccccccccccccccccc();
+// last nullsafe
+$obj->aaaaaaaaaaaaaaaaaaaaaaaa()
+    ->ccccccccccccccccccccccccccccc()
+    ?->ccccccccccccccccccccc();
 
 ================================================================================
 `;

--- a/tests/nullsafepropertylookup/offsets.php
+++ b/tests/nullsafepropertylookup/offsets.php
@@ -16,3 +16,13 @@ $obj?->{call()};
 $obj?->foo_{'test' . 'bar'};
 // variable with literal with call
 $obj?->${call()};
+
+// long methods names chaining
+// all nullsafe
+$obj?->aaaaaaaaaaaaaaaaaaaaaaaa()?->ccccccccccccccccccccccccccccc()?->ccccccccccccccccccccc();
+// first nullsafe
+$obj?->aaaaaaaaaaaaaaaaaaaaaaaa()->ccccccccccccccccccccccccccccc()->ccccccccccccccccccccc();
+// middle nullsafe
+$obj->aaaaaaaaaaaaaaaaaaaaaaaa()?->ccccccccccccccccccccccccccccc()->ccccccccccccccccccccc();
+// last nullsafe
+$obj->aaaaaaaaaaaaaaaaaaaaaaaa()->ccccccccccccccccccccccccccccc()?->ccccccccccccccccccccc();


### PR DESCRIPTION
Fixes #1900 

This makes multiline method chaining like:

```php
$a
   ->bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb()
   ?->ccccccccccccccccccccccccccccccc()
   ->dddddddddddddddddddddddddddddddd();
```

Work correctly when the nullsafe operator `?->` is used somewhere
in the chain.

Output before this PR:
```php
$a->bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb()
    ?->ccccccccccccccccccccccccccccccc()->dddddddddddddddddddddddddddddddd();
```

Ouput after this PR:
```php
$a
   ->bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb()
   ?->ccccccccccccccccccccccccccccccc()
   ->dddddddddddddddddddddddddddddddd();
```