### PR TITLE
[8.1] Add test for covering 'never' return type

### DIFF
--- a/tests/functions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/functions/__snapshots__/jsfmt.spec.js.snap
@@ -82,6 +82,10 @@ function testReturn(?string $name): ?string
     return $name;
 }
 
+function test_return_never(): never {
+    exit();
+}
+
 function swap(&$left, &$right): void
 {
     if ($left === $right) {
@@ -280,6 +284,11 @@ function gen(): iterable
 function testReturn(?string $name): ?string
 {
     return $name;
+}
+
+function test_return_never(): never
+{
+    exit();
 }
 
 function swap(&$left, &$right): void

--- a/tests/functions/functions.php
+++ b/tests/functions/functions.php
@@ -74,6 +74,10 @@ function testReturn(?string $name): ?string
     return $name;
 }
 
+function test_return_never(): never {
+    exit();
+}
+
 function swap(&$left, &$right): void
 {
     if ($left === $right) {


### PR DESCRIPTION
Part of https://github.com/prettier/plugin-php/issues/1691 



PHP 8.1 added the `never` return type. This PR add a unit test to make sure it is supported.

https://php.watch/versions/8.1/never-return-type