### PR TITLE
Attempt to fix the formatting of long cases in match statement

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3034,21 +3034,15 @@ function printNode(path, options, print) {
             : concat(
                 armPath.map(
                   (condPath, condIdx) =>
-                    group(
-                      concat(
-                        condIdx > 0
-                          ? [",", line, print(condPath)]
-                          : [print(condPath)]
-                      )
+                    concat(
+                      [",", line, print(condPath)].slice(condIdx === 0 ? 2 : 0)
                     ),
                   "conds"
                 )
               );
         const body = armPath.call(print, "body");
-        return concat(
-          armIdx > 0
-            ? [", ", hardline, conds, " => ", body]
-            : [hardline, conds, " => ", body]
+        return group(
+          concat([",", hardline, conds, " => ", body].slice(armIdx > 0 ? 0 : 1))
         );
       }, "arms");
       return group(

--- a/tests/match/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/match/__snapshots__/jsfmt.spec.js.snap
@@ -39,6 +39,19 @@ $nest = match(match($a) {true => 1, false => 2}) {
     },
     2 => 'null'
 };
+
+$extraLongMatch = match($a) {
+    'foo', 'foo2', 'foo3', 'foo4',
+    'foo5', 'foo6', 'foo7', 'foo8',
+    'foo9', 'foo10', 'foo11', 'foo12',
+    => ['bar'],
+    'bar', 'bar2', 'bar3', 'bar4',
+    'bar5', 'bar6', 'bar7', 'bar8',
+    'bar9', 'bar10', 'bar11', 'bar12',
+    => 'some really long value in the return part of the match statement',
+    'cd' => [],
+    default => [],
+};
 =====================================output=====================================
 <?php
 
@@ -55,8 +68,12 @@ $boolStr = match ($v) {
 };
 
 $boolish = match ($v) {
-    true, 1 => true,
-    false, 0, "", null => false,
+    true,
+    1 => true,
+    false,
+    0,
+    "",
+    null => false,
     default => null
 };
 
@@ -78,6 +95,35 @@ match ($a) {
         default => false
     },
     2 => "null"
+};
+
+$extraLongMatch = match ($a) {
+    "foo",
+    "foo2",
+    "foo3",
+    "foo4",
+    "foo5",
+    "foo6",
+    "foo7",
+    "foo8",
+    "foo9",
+    "foo10",
+    "foo11",
+    "foo12" => ["bar"],
+    "bar",
+    "bar2",
+    "bar3",
+    "bar4",
+    "bar5",
+    "bar6",
+    "bar7",
+    "bar8",
+    "bar9",
+    "bar10",
+    "bar11",
+    "bar12" => "some really long value in the return part of the match statement",
+    "cd" => [],
+    default => []
 };
 
 ================================================================================
@@ -122,6 +168,19 @@ $nest = match(match($a) {true => 1, false => 2}) {
     },
     2 => 'null'
 };
+
+$extraLongMatch = match($a) {
+    'foo', 'foo2', 'foo3', 'foo4',
+    'foo5', 'foo6', 'foo7', 'foo8',
+    'foo9', 'foo10', 'foo11', 'foo12',
+    => ['bar'],
+    'bar', 'bar2', 'bar3', 'bar4',
+    'bar5', 'bar6', 'bar7', 'bar8',
+    'bar9', 'bar10', 'bar11', 'bar12',
+    => 'some really long value in the return part of the match statement',
+    'cd' => [],
+    default => [],
+};
 =====================================output=====================================
 <?php
 
@@ -138,8 +197,12 @@ $boolStr = match ($v) {
 };
 
 $boolish = match ($v) {
-    true, 1 => true,
-    false, 0, "", null => false,
+    true,
+    1 => true,
+    false,
+    0,
+    "",
+    null => false,
     default => null,
 };
 
@@ -161,6 +224,35 @@ match ($a) {
         default => false,
     },
     2 => "null",
+};
+
+$extraLongMatch = match ($a) {
+    "foo",
+    "foo2",
+    "foo3",
+    "foo4",
+    "foo5",
+    "foo6",
+    "foo7",
+    "foo8",
+    "foo9",
+    "foo10",
+    "foo11",
+    "foo12" => ["bar"],
+    "bar",
+    "bar2",
+    "bar3",
+    "bar4",
+    "bar5",
+    "bar6",
+    "bar7",
+    "bar8",
+    "bar9",
+    "bar10",
+    "bar11",
+    "bar12" => "some really long value in the return part of the match statement",
+    "cd" => [],
+    default => [],
 };
 
 ================================================================================

--- a/tests/match/match.php
+++ b/tests/match/match.php
@@ -29,3 +29,16 @@ $nest = match(match($a) {true => 1, false => 2}) {
     },
     2 => 'null'
 };
+
+$extraLongMatch = match($a) {
+    'foo', 'foo2', 'foo3', 'foo4',
+    'foo5', 'foo6', 'foo7', 'foo8',
+    'foo9', 'foo10', 'foo11', 'foo12',
+    => ['bar'],
+    'bar', 'bar2', 'bar3', 'bar4',
+    'bar5', 'bar6', 'bar7', 'bar8',
+    'bar9', 'bar10', 'bar11', 'bar12',
+    => 'some really long value in the return part of the match statement',
+    'cd' => [],
+    default => [],
+};


### PR DESCRIPTION
This is outputting valid PHP however, for some reason I do not fully understand, it breaks short multiple match cases onto multiple lines.