### PR TITLE
Fix for function curly brace with attrs

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1370,9 +1370,10 @@ function printClass(path, options, print) {
 
 function printFunction(path, options, print) {
   const node = path.getValue();
-  const declaration = [
-    ...printAttrs(path, options, print, { inline: node.kind === "closure" }),
-  ];
+  const declAttrs = printAttrs(path, options, print, {
+    inline: node.kind === "closure",
+  });
+  const declaration = [];
 
   if (node.isFinal) {
     declaration.push("final ");
@@ -1431,7 +1432,7 @@ function printFunction(path, options, print) {
   const printedDeclaration = concat(declaration);
 
   if (!node.body) {
-    return printedDeclaration;
+    return concat([...declAttrs, printedDeclaration]);
   }
 
   const isClosure = node.kind === "closure";
@@ -1445,11 +1446,12 @@ function printFunction(path, options, print) {
   ]);
 
   if (isClosure) {
-    return concat([printedDeclaration, " ", printedBody]);
+    return concat([...declAttrs, printedDeclaration, " ", printedBody]);
   }
 
   if (node.arguments.length === 0) {
     return concat([
+      ...declAttrs,
       printedDeclaration,
       shouldPrintHardlineForOpenBrace(options) ? hardline : " ",
       printedBody,
@@ -1462,13 +1464,16 @@ function printFunction(path, options, print) {
     return concat([printedDeclaration, " ", printedBody]);
   }
 
-  return conditionalGroup([
-    concat([
-      printedDeclaration,
-      shouldPrintHardlineForOpenBrace(options) ? hardline : " ",
-      printedBody,
+  return concat([
+    ...declAttrs,
+    conditionalGroup([
+      concat([
+        printedDeclaration,
+        shouldPrintHardlineForOpenBrace(options) ? hardline : " ",
+        printedBody,
+      ]),
+      concat([printedDeclaration, " ", printedBody]),
     ]),
-    concat([printedDeclaration, " ", printedBody]),
   ]);
 }
 

--- a/tests/attributes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/attributes/__snapshots__/jsfmt.spec.js.snap
@@ -76,6 +76,20 @@ class ValueModel
     public ?string $value = null;
 }
 
+class Test
+{
+    /**
+     * Method with an attribute.
+     * @param string $foo
+     * @return string
+     */
+    #[Pure]
+    public function withAttribute(string $foo): string
+    {
+        return $foo;
+    }
+
+}
 =====================================output=====================================
 <?php
 
@@ -95,7 +109,8 @@ class D
      * @return callable function doubles int
      */
     #[I, J]
-    function k(#[L] int $m): callable {
+    function k(#[L] int $m): callable
+    {
         return #[N, O] #[P] fn(#[Q] int $r) => $r * 2;
     } //Testing T
 
@@ -177,6 +192,20 @@ class ValueModel
         Assert\\Length(max: 255, groups: ["foo"])
     ]
     public ?string $value = null;
+}
+
+class Test
+{
+    /**
+     * Method with an attribute.
+     * @param string $foo
+     * @return string
+     */
+    #[Pure]
+    public function withAttribute(string $foo): string
+    {
+        return $foo;
+    }
 }
 
 ================================================================================

--- a/tests/attributes/attributes.php
+++ b/tests/attributes/attributes.php
@@ -67,3 +67,18 @@ class ValueModel
     ]
     public ?string $value = null;
 }
+
+class Test
+{
+    /**
+     * Method with an attribute.
+     * @param string $foo
+     * @return string
+     */
+    #[Pure]
+    public function withAttribute(string $foo): string
+    {
+        return $foo;
+    }
+
+}


### PR DESCRIPTION
This fix excludes the function block attributes from the function definition, when chcking the line length.

closes #1870