### PR TITLE
Remove handling `\r`

### DIFF
--- a/src/clean.js
+++ b/src/clean.js
@@ -44,7 +44,7 @@ function clean(node, newObj) {
       return null;
     }
 
-    newObj.value = newObj.value.replace(/\r\n?|\n/g, "");
+    newObj.value = newObj.value.replace(/\n/g, "");
   }
 
   // continue ((2)); -> continue 2;

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ const printers = {
             return comment.value;
           }
 
-          const lines = comment.value.split(/\r?\n/g);
+          const lines = comment.value.split("\n");
           // if this is a block comment, handle indentation
           if (
             lines

--- a/src/parser.js
+++ b/src/parser.js
@@ -9,7 +9,7 @@ function parse(text, parsers, opts) {
   }
 
   // Todo https://github.com/glayzzle/php-parser/issues/170
-  text = text.replace(/\?>\r?\n<\?/g, "?>\n___PSEUDO_INLINE_PLACEHOLDER___<?");
+  text = text.replace(/\?>\n<\?/g, "?>\n___PSEUDO_INLINE_PLACEHOLDER___<?");
 
   // initialize a new parser instance
   const parser = new engine({
@@ -52,10 +52,6 @@ function parse(text, parsers, opts) {
   // currently inline comments include the line break at the end, we need to
   // strip those out and update the end location for each comment manually
   ast.comments.forEach((comment) => {
-    if (comment.value[comment.value.length - 1] === "\r") {
-      comment.value = comment.value.slice(0, -1);
-      comment.loc.end.offset = comment.loc.end.offset - 1;
-    }
     if (comment.value[comment.value.length - 1] === "\n") {
       comment.value = comment.value.slice(0, -1);
       comment.loc.end.offset = comment.loc.end.offset - 1;

--- a/src/pragma.js
+++ b/src/pragma.js
@@ -22,16 +22,6 @@ const getPageLevelDocBlock = memoize((text) => {
   }
 });
 
-function guessLineEnding(text) {
-  const index = text.indexOf("\n");
-
-  if (index >= 0 && text.charAt(index - 1) === "\r") {
-    return "\r\n";
-  }
-
-  return "\n";
-}
-
 function hasPragma(text) {
   // fast path optimization - check if the pragma shows up in the file at all
   if (!reHasPragma.test(text)) {
@@ -49,8 +39,8 @@ function hasPragma(text) {
   return false;
 }
 
-function injectPragma(docblock, text) {
-  let lines = docblock.split(/\r?\n/g);
+function injectPragma(docblock) {
+  let lines = docblock.split("\n");
 
   if (lines.length === 1) {
     // normalize to multiline for simplicity
@@ -66,7 +56,7 @@ function injectPragma(docblock, text) {
   // not found => index == -1, which conveniently will splice 1 from the end.
   lines.splice(pragmaIndex, 0, " * @format");
 
-  return lines.join(guessLineEnding(text));
+  return lines.join("\n");
 }
 
 function insertPragma(text) {

--- a/src/printer.js
+++ b/src/printer.js
@@ -2917,7 +2917,7 @@ function printNode(path, options, print) {
         let linebreak = literalline;
         if (parentParent.type === "heredoc") {
           linebreak = flexible ? hardline : literalline;
-          const lines = parentParent.raw.split(/\r?\n/g);
+          const lines = parentParent.raw.split("\n");
           closingTagIndentation = lines[lines.length - 1].search(/\S/);
           if (closingTagIndentation === -1) {
             closingTagIndentation = lines[lines.length - 2].search(/\S/);
@@ -2926,7 +2926,7 @@ function printNode(path, options, print) {
         return join(
           linebreak,
           node.raw
-            .split(/\r?\n/g)
+            .split("\n")
             .map((s, i) =>
               i > 0 || node.loc.start.column === 0
                 ? s.substring(closingTagIndentation)
@@ -2955,7 +2955,7 @@ function printNode(path, options, print) {
       return concat([
         node.raw[0] === "b" ? "b" : "",
         quote,
-        join(literalline, stringValue.split(/\r?\n/g)),
+        join(literalline, stringValue.split("\n")),
         quote,
       ]);
     }
@@ -3002,7 +3002,7 @@ function printNode(path, options, print) {
     case "inline":
       return join(
         literalline,
-        node.raw.replace("___PSEUDO_INLINE_PLACEHOLDER___", "").split(/\r?\n/g)
+        node.raw.replace("___PSEUDO_INLINE_PLACEHOLDER___", "").split("\n")
       );
     case "magic":
       return node.value;
@@ -3014,7 +3014,7 @@ function printNode(path, options, print) {
         node.label,
         "'",
         linebreak,
-        join(linebreak, node.value.split(/\r?\n/g)),
+        join(linebreak, node.value.split("\n")),
         linebreak,
         node.label,
         docShouldHaveTrailingNewline(path) ? hardline : "",


### PR DESCRIPTION
Prettier core normalize line breaks to `\n` before sending to plugin.