### PR TITLE
Update package.json to allow prettier 3.x as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "yarpm": "^1.1.1"
   },
   "peerDependencies": {
-    "prettier": "^1.15.0 || ^2.0.0"
+    "prettier": "^1.15.0 || 2 || 3"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
It looks like this should run just fine with prettier 3.x so this just updates the package.json to reflect that