### PR TITLE
Add constraint for Prettier 3 in peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "yarpm": "^1.1.1"
   },
   "peerDependencies": {
-    "prettier": "^1.15.0 || ^2.0.0"
+    "prettier": "^1.15.0 || ^2.0.0 || ^3.0.0"
   },
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prettier/plugin-php",
-  "version": "0.19.6",
+  "version": "0.20.0",
   "description": "Prettier PHP Plugin",
   "repository": "prettier/prettier-php",
   "author": "Lucas Azzola <@azz>",


### PR DESCRIPTION
`npm test` succeeded... not allowing Prettier 3 forces importing this and other plugins as a CJS module, which breaks other plugins that export as ES modules