### PR TITLE
Fix magic methods detection

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2888,7 +2888,7 @@ function printNode(path, options, print) {
     case "error":
     default:
       // istanbul ignore next
-      return `Have not implemented kind ${node.kind} yet.`;
+      throw new Error(`Have not implemented kind '${node.kind}' yet.`);
   }
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -648,7 +648,7 @@ function getAncestorNode(path, typeOrTypes) {
   return counter === -1 ? null : path.getParentNode(counter);
 }
 
-const magicMethods = new Set([
+const magicMethods = [
   "__construct",
   "__destruct",
   "__call",
@@ -664,13 +664,16 @@ const magicMethods = new Set([
   "__set_state",
   "__clone",
   "__debugInfo",
-]);
+];
+const magicMethodsMap = new Map(
+  magicMethods.map((name) => [name.toLowerCase(), name])
+);
 
 function normalizeMagicMethodName(name) {
   const loweredName = name.toLowerCase();
 
-  if (magicMethods.has(loweredName)) {
-    return loweredName;
+  if (magicMethodsMap.has(loweredName)) {
+    return magicMethodsMap.get(loweredName);
   }
 
   return name;

--- a/src/util.js
+++ b/src/util.js
@@ -648,7 +648,7 @@ function getAncestorNode(path, typeOrTypes) {
   return counter === -1 ? null : path.getParentNode(counter);
 }
 
-const magicMethods = [
+const magicMethods = new Set([
   "__construct",
   "__destruct",
   "__call",
@@ -664,18 +664,13 @@ const magicMethods = [
   "__set_state",
   "__clone",
   "__debugInfo",
-];
-const MagicMethodsMap = magicMethods.reduce((map, obj) => {
-  map[obj.toLowerCase()] = obj;
-
-  return map;
-}, {});
+]);
 
 function normalizeMagicMethodName(name) {
   const loweredName = name.toLowerCase();
 
-  if (MagicMethodsMap[loweredName]) {
-    return MagicMethodsMap[loweredName];
+  if (magicMethods.has(loweredName)) {
+    return loweredName;
   }
 
   return name;

--- a/tests/case/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/case/__snapshots__/jsfmt.spec.js.snap
@@ -595,7 +595,7 @@ class Connection
     {
     }
 
-    public static function __CALLSTATIC($name, $arguments)
+    public static function __callStatic($name, $arguments)
     {
     }
 
@@ -623,7 +623,7 @@ class Connection
     {
     }
 
-    public function __TOSTRING()
+    public function __toString()
     {
     }
 
@@ -639,7 +639,7 @@ class Connection
     {
     }
 
-    public function __DEBUGINFO()
+    public function __debugInfo()
     {
     }
 

--- a/tests/case/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/case/__snapshots__/jsfmt.spec.js.snap
@@ -569,6 +569,10 @@ class Connection
     public function __DEBUGINFO()
     {
     }
+
+    // Not magic methods, JS Object prototype properties
+    public function __pRoTo__() {}
+    public function cOnStRuCtOr() {}
 }
 
 =====================================output=====================================
@@ -591,7 +595,7 @@ class Connection
     {
     }
 
-    public static function __callStatic($name, $arguments)
+    public static function __CALLSTATIC($name, $arguments)
     {
     }
 
@@ -619,7 +623,7 @@ class Connection
     {
     }
 
-    public function __toString()
+    public function __TOSTRING()
     {
     }
 
@@ -635,7 +639,15 @@ class Connection
     {
     }
 
-    public function __debugInfo()
+    public function __DEBUGINFO()
+    {
+    }
+
+    // Not magic methods, JS Object prototype properties
+    public function __pRoTo__()
+    {
+    }
+    public function cOnStRuCtOr()
     {
     }
 }

--- a/tests/case/magic-methods.php
+++ b/tests/case/magic-methods.php
@@ -64,4 +64,8 @@ class Connection
     public function __DEBUGINFO()
     {
     }
+
+    // Not magic methods, JS Object prototype properties
+    public function __pRoTo__() {}
+    public function cOnStRuCtOr() {}
 }


### PR DESCRIPTION
Input:

```php
<?php
class Foo
{
    public function __pRoTo__() {}
    public function cOnStRuCtOr() {}
}
```

Output:

```php
<?php
class Foo
{
    public function Have not implemented kind undefined yet.()
    {
    }
    public function Have not implemented kind undefined yet.()
    {
    }
}
```