### PR TITLE
fix(match): Indent match conditions

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2847,7 +2847,7 @@ function printNode(path, options, print) {
       }, "arms");
       return group([
         "match (",
-        group([softline, indent(print("cond")), softline]),
+        group([indent([softline, print("cond")]), softline]),
         ") {",
         group(indent([...arms])),
         " ",

--- a/tests/match/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/match/__snapshots__/jsfmt.spec.js.snap
@@ -66,6 +66,10 @@ match ($a) {
 
 };
 
+match($really_really_really_really_really_really_really_really_long_variable_name) {
+default => null
+};
+
 =====================================output=====================================
 <?php
 
@@ -94,7 +98,7 @@ $a = match (true) {
 };
 
 $nest = match (
-match ($a) {
+    match ($a) {
         true => 1,
         false => 2
     }
@@ -146,6 +150,12 @@ match ($a) {
     "a" => 1,
 
     "b" => 2
+};
+
+match (
+    $really_really_really_really_really_really_really_really_long_variable_name
+) {
+    default => null
 };
 
 ================================================================================
@@ -217,6 +227,10 @@ match ($a) {
 
 };
 
+match($really_really_really_really_really_really_really_really_long_variable_name) {
+default => null
+};
+
 =====================================output=====================================
 <?php
 
@@ -245,7 +259,7 @@ $a = match (true) {
 };
 
 $nest = match (
-match ($a) {
+    match ($a) {
         true => 1,
         false => 2,
     }
@@ -297,6 +311,12 @@ match ($a) {
     "a" => 1,
 
     "b" => 2,
+};
+
+match (
+    $really_really_really_really_really_really_really_really_long_variable_name
+) {
+    default => null,
 };
 
 ================================================================================

--- a/tests/match/match.php
+++ b/tests/match/match.php
@@ -55,3 +55,7 @@ match ($a) {
     'b' => 2
 
 };
+
+match($really_really_really_really_really_really_really_really_long_variable_name) {
+default => null
+};


### PR DESCRIPTION
This updates `match($cond)` printing to ... er ... match `if ($cond)` (etc) when the condition can't fit onto a single line.

## Input
```php
match($really_really_really_really_really_really_really_really_long_variable_name) {
default => null
};
```

## Current behavior on `master`
```php
match(
$really_really_really_really_really_really_really_really_long_variable_name
) {
    default => null
};
```

## Behavior with this change
```php
match(
    $really_really_really_really_really_really_really_really_long_variable_name
) {
    default => null
};
```

I added a test to the snapsnots, and this change also corrects/changes one of the other `match` snapshots.