### PR TITLE
feat: make format compatible with "PER Coding Style 2.0"

### DIFF
--- a/src/printer.mjs
+++ b/src/printer.mjs
@@ -1204,12 +1204,12 @@ function printClass(path, options, print) {
   const attrs = printAttrs(path, options, print, { inline: isAnonymousClass });
   const declaration = isAnonymousClass ? [] : [...attrs];
 
-  if (node.isReadonly) {
-    declaration.push("readonly ");
-  }
-
   if (node.isFinal) {
     declaration.push("final ");
+  }
+
+  if (node.isReadonly) {
+    declaration.push("readonly ");
   }
 
   if (node.isAbstract) {

--- a/src/printer.mjs
+++ b/src/printer.mjs
@@ -1208,12 +1208,12 @@ function printClass(path, options, print) {
     declaration.push("final ");
   }
 
-  if (node.isReadonly) {
-    declaration.push("readonly ");
-  }
-
   if (node.isAbstract) {
     declaration.push("abstract ");
+  }
+
+  if (node.isReadonly) {
+    declaration.push("readonly ");
   }
 
   // `new` print `class` keyword with arguments

--- a/tests/class/__snapshots__/jsfmt.spec.mjs.snap
+++ b/tests/class/__snapshots__/jsfmt.spec.mjs.snap
@@ -903,11 +903,15 @@ abstract class BaseClass {}
 
 final readonly class BaseClass {}
 
+readonly final class BaseClass {}
+
 final class BaseClass extends MyOtherClass {}
 
 abstract class BaseClass extends MyOtherClass {}
 
 final readonly class BaseClass extends MyOtherClass {}
+
+readonly final class BaseClass extends MyOtherClass {}
 
 final class BaseClass extends MyOtherVeryVeryVeryVeVeryVeryVeryVeryVeryLongClass {}
 
@@ -1406,11 +1410,19 @@ final readonly class BaseClass
 {
 }
 
+final readonly class BaseClass
+{
+}
+
 final class BaseClass extends MyOtherClass
 {
 }
 
 abstract class BaseClass extends MyOtherClass
+{
+}
+
+final readonly class BaseClass extends MyOtherClass
 {
 }
 

--- a/tests/class/__snapshots__/jsfmt.spec.mjs.snap
+++ b/tests/class/__snapshots__/jsfmt.spec.mjs.snap
@@ -901,9 +901,13 @@ final class BaseClass {}
 
 abstract class BaseClass {}
 
+final readonly class BaseClass {}
+
 final class BaseClass extends MyOtherClass {}
 
 abstract class BaseClass extends MyOtherClass {}
+
+final readonly class BaseClass extends MyOtherClass {}
 
 final class BaseClass extends MyOtherVeryVeryVeryVeVeryVeryVeryVeryVeryLongClass {}
 
@@ -1398,11 +1402,19 @@ abstract class BaseClass
 {
 }
 
+final readonly class BaseClass
+{
+}
+
 final class BaseClass extends MyOtherClass
 {
 }
 
 abstract class BaseClass extends MyOtherClass
+{
+}
+
+final readonly class BaseClass extends MyOtherClass
 {
 }
 

--- a/tests/class/class.php
+++ b/tests/class/class.php
@@ -268,11 +268,15 @@ abstract class BaseClass {}
 
 final readonly class BaseClass {}
 
+readonly final class BaseClass {}
+
 final class BaseClass extends MyOtherClass {}
 
 abstract class BaseClass extends MyOtherClass {}
 
 final readonly class BaseClass extends MyOtherClass {}
+
+readonly final class BaseClass extends MyOtherClass {}
 
 final class BaseClass extends MyOtherVeryVeryVeryVeVeryVeryVeryVeryVeryLongClass {}
 

--- a/tests/class/class.php
+++ b/tests/class/class.php
@@ -266,9 +266,13 @@ final class BaseClass {}
 
 abstract class BaseClass {}
 
+final readonly class BaseClass {}
+
 final class BaseClass extends MyOtherClass {}
 
 abstract class BaseClass extends MyOtherClass {}
+
+final readonly class BaseClass extends MyOtherClass {}
 
 final class BaseClass extends MyOtherVeryVeryVeryVeVeryVeryVeryVeryVeryLongClass {}
 


### PR DESCRIPTION
This change allows to use this plugin along with "PER Coding Style 2.0"
formating :
`readonly final class ClassName {}`
to
`final readonly class ClassName {}`

doc:
https://www.php-fig.org/per/coding-style/#46-modifier-keywords
