### PR TITLE
fix: 🐛 singleQuote option does not work on format API

### DIFF
--- a/src/options.mjs
+++ b/src/options.mjs
@@ -45,4 +45,11 @@ export default {
       { value: "1tbs", description: "Use 1tbs brace style." },
     ],
   },
+  singleQuote: {
+    since: "0.0.0",
+    category: CATEGORY_PHP,
+    type: "boolean",
+    default: false,
+    description: "Use single quotes instead of double quotes.",
+  }
 };

--- a/src/options.mjs
+++ b/src/options.mjs
@@ -51,5 +51,5 @@ export default {
     type: "boolean",
     default: false,
     description: "Use single quotes instead of double quotes.",
-  }
+  },
 };

--- a/tests/single-quote-api/jsfmt.spec.mjs
+++ b/tests/single-quote-api/jsfmt.spec.mjs
@@ -1,0 +1,20 @@
+import prettier from "prettier/standalone";
+import * as prettierPluginPhp from "../../src/index.mjs";
+
+test(`singleQuote`, async () => {
+  const input = `<?php echo link_to_route("frontend.users.user.show", $users["name"], $users['_id']); ?>`;
+  const result = await prettier.format(input, {
+    plugins: [prettierPluginPhp],
+    singleQuote: true,
+    parser: "php",
+  });
+
+  const expected = `<?php echo link_to_route(
+    'frontend.users.user.show',
+    $users['name'],
+    $users['_id']
+); ?>
+`;
+
+  expect(result).toEqual(expected);
+});

--- a/tests/single-quote-api/jsfmt.spec.mjs
+++ b/tests/single-quote-api/jsfmt.spec.mjs
@@ -1,7 +1,8 @@
 import prettier from "prettier/standalone";
 import * as prettierPluginPhp from "../../src/index.mjs";
 
-test(`singleQuote`, async () => {
+// https://github.com/prettier/plugin-php/issues/2302
+test(`singleQuote option on format api`, async () => {
   const input = `<?php echo link_to_route("frontend.users.user.show", $users["name"], $users['_id']); ?>`;
   const result = await prettier.format(input, {
     plugins: [prettierPluginPhp],


### PR DESCRIPTION
## Description
This PR fixes #2302. `singleQuote` option regression on format API.

## Related Issue
- Fixes: #2302

## How it has been tested?
Added test for format api call. Please point out if this test method is not allowed in this project.