### PR TITLE
Adjustment for overlooked nested lookups in chain breaks

### DIFF
--- a/src/printer.mjs
+++ b/src/printer.mjs
@@ -509,8 +509,8 @@ function printMemberChain(path, options, print) {
     printIndentedGroup(groups.slice(shouldMerge ? 2 : 1)),
   ];
 
-  const callExpressions = printedNodes.filter((tuple) =>
-    ["call", "new"].includes(tuple.node.kind)
+  const callExpressions = printedNodes.filter(
+    (tuple) => tuple.node.kind === "call"
   );
 
   // We don't want to print in one line if there's:

--- a/src/util.mjs
+++ b/src/util.mjs
@@ -622,27 +622,35 @@ function createTypeCheckFunction(kindsArray) {
 }
 
 const isSingleWordType = createTypeCheckFunction([
-  "variable",
+  "variadicplaceholder",
+  "namedargument",
+  "nullkeyword",
+  "identifier",
   "parameter",
+  "variable",
   "variadic",
-  "clone",
-  "cast",
   "boolean",
+  "literal",
   "number",
   "string",
-  "literal",
-  "nullkeyword",
-  "namedargument",
-  "variadicplaceholder",
+  "clone",
+  "cast",
 ]);
 
 const isArrayExpression = createTypeCheckFunction(["array"]);
-const isCallOrNewExpression = createTypeCheckFunction(["call", "new"]);
+const isCallLikeExpression = createTypeCheckFunction([
+  "nullsafepropertylookup",
+  "propertylookup",
+  "staticlookup",
+  "offsetlookup",
+  "call",
+  "new",
+]);
 const isArrowFuncExpression = createTypeCheckFunction(["arrowfunc"]);
 
 function getChainParts(node, prev = []) {
   const parts = prev;
-  if (isCallOrNewExpression(node)) {
+  if (isCallLikeExpression(node)) {
     parts.push(node);
   }
 
@@ -668,11 +676,17 @@ function isSimpleCallArgument(node, depth = 2) {
     return node.items.every((x) => x === null || isChildSimple(x));
   }
 
-  if (isCallOrNewExpression(node)) {
+  if (isCallLikeExpression(node)) {
     const parts = getChainParts(node);
+    parts.unshift();
+
     return (
-      parts.filter((node) => node.kind === "call").length <= depth &&
-      parts.every((node) => node.arguments.every(isChildSimple))
+      parts.length <= depth &&
+      parts.every((node) =>
+        isLookupNode(node)
+          ? isChildSimple(node?.offset)
+          : node.arguments.every(isChildSimple)
+      )
     );
   }
 

--- a/src/util.mjs
+++ b/src/util.mjs
@@ -684,7 +684,7 @@ function isSimpleCallArgument(node, depth = 2) {
       parts.length <= depth &&
       parts.every((node) =>
         isLookupNode(node)
-          ? isChildSimple(node?.offset)
+          ? isChildSimple(node.offset)
           : node.arguments.every(isChildSimple)
       )
     );

--- a/tests/member_chain/__snapshots__/jsfmt.spec.mjs.snap
+++ b/tests/member_chain/__snapshots__/jsfmt.spec.mjs.snap
@@ -583,11 +583,9 @@ $var = Foo::keys($items)
         return $x * 2;
     });
 
-(new static(func_get_args()))
-    ->push($this)
-    ->each(function ($item) {
-        VarDumper::dump($item);
-    });
+(new static(func_get_args()))->push($this)->each(function ($item) {
+    VarDumper::dump($item);
+});
 (new static(func_get_args()))
     ->offset(10)
     ->push($this)
@@ -721,6 +719,16 @@ $window->{call()}
         return $b;
     });
 
+
+$window->call($foo->bar->baz)->first()->second();
+$window->call($foo->bar->baz->foo())->first()->second();
+
+(new Foo())->call($foo->bar->baz)->first()->second();
+(new Foo())->call($foo->bar->baz->foo())->first()->second();
+
+Foo::call($foo->bar->baz)->first()->second();
+Foo::call($foo->bar->baz->foo())->first()->second();
+
 =====================================output=====================================
 <?php
 
@@ -797,6 +805,23 @@ $window->{call()}
     ->catch(function () {
         return $b;
     });
+
+$window->call($foo->bar->baz)->first()->second();
+$window
+    ->call($foo->bar->baz->foo())
+    ->first()
+    ->second();
+
+(new Foo())->call($foo->bar->baz)->first()->second();
+(new Foo())
+    ->call($foo->bar->baz->foo())
+    ->first()
+    ->second();
+
+Foo::call($foo->bar->baz)->first()->second();
+Foo::call($foo->bar->baz->foo())
+    ->first()
+    ->second();
 
 ================================================================================
 `;

--- a/tests/member_chain/offsetlookup.php
+++ b/tests/member_chain/offsetlookup.php
@@ -53,3 +53,13 @@ $window->{call()}
     ->catch(function () {
         return $b;
     });
+
+
+$window->call($foo->bar->baz)->first()->second();
+$window->call($foo->bar->baz->foo())->first()->second();
+
+(new Foo())->call($foo->bar->baz)->first()->second();
+(new Foo())->call($foo->bar->baz->foo())->first()->second();
+
+Foo::call($foo->bar->baz)->first()->second();
+Foo::call($foo->bar->baz->foo())->first()->second();


### PR DESCRIPTION
I have adjusted chain breaks for nested lookups which were overlooked in previous pull request. Also the break should now be consistent between `Test::foo()->`, `(new Test())->`, `$test['foo']` etc.