### PR TITLE
chore(deps): 🤖 bump php-parser from 3.1.5 to 3.2.1

### DIFF
--- a/tests/nullsafepropertylookup/__snapshots__/jsfmt.spec.mjs.snap
+++ b/tests/nullsafepropertylookup/__snapshots__/jsfmt.spec.mjs.snap
@@ -76,3 +76,31 @@ $obj->aaaaaaaaaaaaaaaaaaaaaaaa()
 
 ================================================================================
 `;
+
+exports[`reserved-keyword.php 1`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.0"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+// keyword: abstract
+echo $post->metaData?->abstract;
+
+// keyword: class
+echo $record->learner->currentEnrollment?->class->grade->code;
+
+
+=====================================output=====================================
+<?php
+
+// keyword: abstract
+echo $post->metaData?->abstract;
+
+// keyword: class
+echo $record->learner->currentEnrollment?->class->grade->code;
+
+================================================================================
+`;

--- a/tests/nullsafepropertylookup/reserved-keyword.php
+++ b/tests/nullsafepropertylookup/reserved-keyword.php
@@ -1,0 +1,8 @@
+<?php
+
+// keyword: abstract
+echo $post->metaData?->abstract;
+
+// keyword: class
+echo $record->learner->currentEnrollment?->class->grade->code;
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -5008,9 +5008,9 @@ path-type@^4.0.0:
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
 php-parser@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/php-parser/-/php-parser-3.1.5.tgz#84500e5b5c6a0907e32c38b931bb4e7d3f275026"
-  integrity sha512-jEY2DcbgCm5aclzBdfW86GM6VEIWcSlhTBSHN1qhJguVePlYe28GhwS0yoeLYXpM2K8y6wzLwrbq814n2PHSoQ==
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/php-parser/-/php-parser-3.2.1.tgz#960916dc03e4979a59435f9dd9eb03f2e86d8126"
+  integrity sha512-WT5AMqe39ZdqAxp9Yp7uR6e3clBWlT1dxHHs49GmnDx2d+975NEiLSVy2tRGLdSC9tgdQOLiN1Yz54g1d2cZDQ==
 
 picocolors@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Context
This PR bumps php-parser dependency from 3.1.5 to 3.2.1

- added test for php keyword after null safe lookup fixed at https://github.com/glayzzle/php-parser/releases/tag/3.2.0