### PR TITLE
feat: format new without parenthesis in PHP 8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "linguist-languages": "^8.0.0",
-    "php-parser": "^3.2.4"
+    "php-parser": "^3.2.5"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.27.2",

--- a/src/needs-parens.mjs
+++ b/src/needs-parens.mjs
@@ -1,4 +1,9 @@
-import { getPrecedence, shouldFlatten, isBitwiseOperator } from "./util.mjs";
+import {
+  getPrecedence,
+  shouldFlatten,
+  isBitwiseOperator,
+  isMinVersion,
+} from "./util.mjs";
 
 function needsParens(path, options) {
   const { parent } = path;
@@ -128,13 +133,16 @@ function needsParens(path, options) {
     }
     case "clone":
     case "new": {
+      const requiresParens =
+        node.kind === "clone" ||
+        (node.kind === "new" && !isMinVersion(options.phpVersion, "8.4"));
       switch (parent.kind) {
         case "propertylookup":
         case "nullsafepropertylookup":
         case "staticlookup":
         case "offsetlookup":
         case "call":
-          return key === "what";
+          return key === "what" && requiresParens;
         default:
           return false;
       }

--- a/src/needs-parens.mjs
+++ b/src/needs-parens.mjs
@@ -1,6 +1,6 @@
 import { getPrecedence, shouldFlatten, isBitwiseOperator } from "./util.mjs";
 
-function needsParens(path) {
+function needsParens(path, options) {
   const { parent } = path;
 
   if (!parent) {

--- a/src/options.mjs
+++ b/src/options.mjs
@@ -24,6 +24,7 @@ export default {
       { value: "8.1" },
       { value: "8.2" },
       { value: "8.3" },
+      { value: "8.4" },
     ],
   },
   trailingCommaPHP: {

--- a/src/parser.mjs
+++ b/src/parser.mjs
@@ -1,4 +1,5 @@
 import engine from "php-parser";
+import options from "./options.mjs";
 
 function parse(text, opts) {
   const inMarkdown = opts && opts.parentParser === "markdown";
@@ -10,10 +11,15 @@ function parse(text, opts) {
   // Todo https://github.com/glayzzle/php-parser/issues/170
   text = text.replace(/\?>\n<\?/g, "?>\n___PSEUDO_INLINE_PLACEHOLDER___<?");
 
+  const latestSupportedPhpVersion = Math.max(
+    ...options.phpVersion.choices.map((c) => parseFloat(c.value))
+  );
+
   // initialize a new parser instance
   const parser = new engine({
     parser: {
       extractDoc: true,
+      version: `${latestSupportedPhpVersion}`,
     },
     ast: {
       withPositions: true,

--- a/src/printer.mjs
+++ b/src/printer.mjs
@@ -37,6 +37,7 @@ import {
   isReferenceLikeNode,
   normalizeMagicMethodName,
   isSimpleCallArgument,
+  isMinVersion,
 } from "./util.mjs";
 
 const {
@@ -64,10 +65,6 @@ const {
   isNextLineEmpty,
   isPreviousLineEmpty,
 } = prettierUtil;
-
-function isMinVersion(actualVersion, requiredVersion) {
-  return parseFloat(actualVersion) >= parseFloat(requiredVersion);
-}
 
 function shouldPrintComma(options, requiredVersion) {
   if (!options.trailingCommaPHP) {

--- a/src/util.mjs
+++ b/src/util.mjs
@@ -709,6 +709,10 @@ function memoize(fn) {
   };
 }
 
+function isMinVersion(actualVersion, requiredVersion) {
+  return parseFloat(actualVersion) >= parseFloat(requiredVersion);
+}
+
 export {
   printNumber,
   getPrecedence,
@@ -740,4 +744,5 @@ export {
   normalizeMagicMethodName,
   isSimpleCallArgument,
   memoize,
+  isMinVersion,
 };

--- a/tests/new/__snapshots__/jsfmt.spec.mjs.snap
+++ b/tests/new/__snapshots__/jsfmt.spec.mjs.snap
@@ -433,3 +433,440 @@ $client = new (config("longstringvariable", "longerstringvariable")([
 
 ================================================================================
 `;
+
+exports[`new.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+new Foo;
+new Foo();
+$a = new Foo;
+$b = new Foo();
+$c = new Foo([1, 2, 3], "foo", $variable);
+$bar = 'MyClassName';
+$foo = new $bar;
+$foo = new $bar();
+
+abstract class A
+{
+    public static function create()
+    {
+        $a = new static;
+        $b = new static();
+    }
+
+}
+
+$class = (new Foo)->veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongMethod();
+$class = (new Foo(['VeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey' => 'VeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue']))->veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongMethod();
+$class = (new PendingDispatch(new $this->class(...func_get_args())))->chain($this->chain);
+$dumper = in_array(PHP_SAPI, ['cli', 'phpdbg']) ? new CliDumper : new HtmlDumper;
+$class = new static('Error encoding model ['.get_class($model).'] with ID ['.$model->getKey().'] to JSON: '.$message);
+$response = new \\Illuminate\\Http\\JsonResponse(new JsonResponseTestJsonSerializeObject);
+$result = (new Pipeline(new \\Illuminate\\Container\\Container))
+    ->send('foo')
+    ->through([new PipelineTestPipeOne])
+    ->then(function ($piped) {
+        return $piped;
+    });
+
+$var = new Foo(
+<<<'EOD'
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOD
+    ,
+    $arg
+);
+
+$var = new Foo(
+    $arg,
+    <<<'EOD'
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOD
+);
+
+$var = new Foo(
+    $arg,
+    <<<'EOD'
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOD
+    ,
+    $arg
+);
+
+$var = new Foo(
+    <<<EOF
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOF
+    ,
+    $arg
+);
+
+$var = new Foo(
+    $arg,
+    <<<EOF
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOF
+);
+
+$var = new Foo(
+    $arg,
+    <<<EOF
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOF
+    ,
+    $arg
+);
+
+$var = new class {
+    public function log($msg)
+    {
+        echo $msg;
+    }
+};
+setLogger(new class {
+    public function log($msg)
+    {
+        echo $msg;
+    }
+});
+$var = new class ($arg, 'string', 2100, $var ? true : false, $other_arg, function () { return 1; }) extends SomeClass implements SomeInterface {
+    public function log($msg)
+    {
+        echo $msg;
+    }
+};
+
+$var = new class {};
+$var = new class() {};
+
+class A {
+    public function create1() {
+        $class = get_class($this);
+        return new $class();
+    }
+    public function create2() {
+        return new static();
+    }
+    public function create3() {
+        return new static($arg, $arg, $arg);
+    }
+}
+
+new Foo('string
+string
+string');
+
+new Foo(
+    'string
+string
+string'
+);
+
+new Foo($a, 'string
+string
+string'
+);
+
+new Foo('string
+string
+string', $b
+);
+
+new Foo("string
+string
+string
+$var");
+new Foo(
+"string
+string
+string
+$var"
+);
+new Foo(\`string
+string
+string
+$var\`);
+new Foo(
+\`string
+string
+string
+$var\`
+);
+
+$var = new class('string
+string
+string') {};
+
+$var = new class(
+    'string
+string
+string'
+) {};
+
+$var = new class(10) extends SomeClass implements SomeInterface {
+    private $num;
+
+    public function __construct($num)
+    {
+        $this->num = $num;
+    }
+
+    use SomeTrait;
+};
+
+$a = new (b('c')['d']);
+$client = new (config('longstringvariable','longerstringvariable')(['name'=>$myLongClassname['name']]));
+
+=====================================output=====================================
+<?php
+new Foo();
+new Foo();
+$a = new Foo();
+$b = new Foo();
+$c = new Foo([1, 2, 3], "foo", $variable);
+$bar = "MyClassName";
+$foo = new $bar();
+$foo = new $bar();
+
+abstract class A
+{
+    public static function create()
+    {
+        $a = new static();
+        $b = new static();
+    }
+}
+
+$class = (new Foo())->veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongMethod();
+$class = (new Foo([
+    "VeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey" =>
+        "VeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue",
+]))->veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongMethod();
+$class = (new PendingDispatch(new $this->class(...func_get_args())))->chain(
+    $this->chain,
+);
+$dumper = in_array(PHP_SAPI, ["cli", "phpdbg"])
+    ? new CliDumper()
+    : new HtmlDumper();
+$class = new static(
+    "Error encoding model [" .
+        get_class($model) .
+        "] with ID [" .
+        $model->getKey() .
+        "] to JSON: " .
+        $message,
+);
+$response = new \\Illuminate\\Http\\JsonResponse(
+    new JsonResponseTestJsonSerializeObject(),
+);
+$result = (new Pipeline(new \\Illuminate\\Container\\Container()))
+    ->send("foo")
+    ->through([new PipelineTestPipeOne()])
+    ->then(function ($piped) {
+        return $piped;
+    });
+
+$var = new Foo(
+    <<<'EOD'
+    Example of string
+    spanning multiple lines
+    using nowdoc syntax.
+    EOD
+    ,
+    $arg,
+);
+
+$var = new Foo(
+    $arg,
+    <<<'EOD'
+    Example of string
+    spanning multiple lines
+    using nowdoc syntax.
+    EOD
+    ,
+);
+
+$var = new Foo(
+    $arg,
+    <<<'EOD'
+    Example of string
+    spanning multiple lines
+    using nowdoc syntax.
+    EOD
+    ,
+    $arg,
+);
+
+$var = new Foo(
+    <<<EOF
+    Example of string
+    spanning multiple lines
+    using nowdoc syntax.
+    EOF
+    ,
+    $arg,
+);
+
+$var = new Foo(
+    $arg,
+    <<<EOF
+    Example of string
+    spanning multiple lines
+    using nowdoc syntax.
+    EOF
+    ,
+);
+
+$var = new Foo(
+    $arg,
+    <<<EOF
+    Example of string
+    spanning multiple lines
+    using nowdoc syntax.
+    EOF
+    ,
+    $arg,
+);
+
+$var = new class {
+    public function log($msg)
+    {
+        echo $msg;
+    }
+};
+setLogger(
+    new class {
+        public function log($msg)
+        {
+            echo $msg;
+        }
+    },
+);
+$var = new class (
+    $arg,
+    "string",
+    2100,
+    $var ? true : false,
+    $other_arg,
+    function () {
+        return 1;
+    },
+) extends SomeClass implements SomeInterface {
+    public function log($msg)
+    {
+        echo $msg;
+    }
+};
+
+$var = new class {};
+$var = new class {};
+
+class A
+{
+    public function create1()
+    {
+        $class = get_class($this);
+        return new $class();
+    }
+    public function create2()
+    {
+        return new static();
+    }
+    public function create3()
+    {
+        return new static($arg, $arg, $arg);
+    }
+}
+
+new Foo('string
+string
+string');
+
+new Foo(
+    'string
+string
+string',
+);
+
+new Foo(
+    $a,
+    'string
+string
+string',
+);
+
+new Foo(
+    'string
+string
+string',
+    $b,
+);
+
+new Foo("string
+string
+string
+$var");
+new Foo(
+    "string
+string
+string
+$var",
+);
+new Foo(\`string
+string
+string
+$var\`);
+new Foo(
+    \`string
+string
+string
+$var\`,
+);
+
+$var = new class (
+    'string
+string
+string',
+) {};
+
+$var = new class (
+    'string
+string
+string',
+) {};
+
+$var = new class (10) extends SomeClass implements SomeInterface {
+    private $num;
+
+    public function __construct($num)
+    {
+        $this->num = $num;
+    }
+
+    use SomeTrait;
+};
+
+$a = new (b("c")["d"])();
+$client = new (config("longstringvariable", "longerstringvariable")([
+    "name" => $myLongClassname["name"],
+]))();
+
+================================================================================
+`;

--- a/tests/new/__snapshots__/jsfmt.spec.mjs.snap
+++ b/tests/new/__snapshots__/jsfmt.spec.mjs.snap
@@ -654,12 +654,12 @@ abstract class A
     }
 }
 
-$class = (new Foo())->veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongMethod();
-$class = (new Foo([
+$class = new Foo()->veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongMethod();
+$class = new Foo([
     "VeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey" =>
         "VeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue",
-]))->veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongMethod();
-$class = (new PendingDispatch(new $this->class(...func_get_args())))->chain(
+])->veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongMethod();
+$class = new PendingDispatch(new $this->class(...func_get_args()))->chain(
     $this->chain,
 );
 $dumper = in_array(PHP_SAPI, ["cli", "phpdbg"])
@@ -676,7 +676,7 @@ $class = new static(
 $response = new \\Illuminate\\Http\\JsonResponse(
     new JsonResponseTestJsonSerializeObject(),
 );
-$result = (new Pipeline(new \\Illuminate\\Container\\Container()))
+$result = new Pipeline(new \\Illuminate\\Container\\Container())
     ->send("foo")
     ->through([new PipelineTestPipeOne()])
     ->then(function ($piped) {

--- a/tests/new/jsfmt.spec.mjs
+++ b/tests/new/jsfmt.spec.mjs
@@ -1,1 +1,2 @@
 run_spec(import.meta, ["php"]);
+run_spec(import.meta, ["php"], { phpVersion: "8.4" });

--- a/tests/parens/__snapshots__/jsfmt.spec.mjs.snap
+++ b/tests/parens/__snapshots__/jsfmt.spec.mjs.snap
@@ -4865,11 +4865,11 @@ $var = $var[0][1]::foo();
 $var = $var[0]->foo()->baz;
 $var = $var[0]->foo()->baz;
 
-$var = (new Foo())->bar;
-$var = (new Foo())::bar;
-$var = (new Foo())->bar();
-$var = (new Foo())::bar();
-$var = (new Foo())[1];
+$var = new Foo()->bar;
+$var = new Foo()::bar;
+$var = new Foo()->bar();
+$var = new Foo()::bar();
+$var = new Foo()[1];
 
 $var = $var->bar()();
 $var = $var->bar()();
@@ -4979,6 +4979,9 @@ printWidth: 80
 $var = new Foo();
 $var = (new Foo());
 $var = (new Foo())->c();
+new Foo->prop;
+new Foo->method();
+new Foo->$var;
 $var = (new class {
     public function log($msg)
     {
@@ -4994,8 +4997,16 @@ $var = ((((new foo())->bar())->foo())[0])[1];
 $var = (((new foo())->bar())->foo())->baz();
 $var = (new $foo())->bar;
 $var = (new $bar->y)->x;
+new SortOfLongClassName()->withALongMethodName()->andAnother()->toPushItPast80Chars();
+$asdf =
+new SortOfLongClassName()->withALongMethodName()
+    ->andAnother()->toPushItPast80Chars();
+
 $var = (new foo)[0];
 $var = (new foo)[0]['string'];
+
+$var = (new Foo)::foo;
+$var = (new Foo)::$foo;
 
 $var = new $a->b;
 $var = new $a->b();
@@ -5028,6 +5039,9 @@ new Translator(
 $var = new Foo();
 $var = new Foo();
 $var = (new Foo())->c();
+(new Foo())->prop;
+(new Foo())->method();
+(new Foo())->$var;
 $var = new class {
     public function log($msg)
     {
@@ -5043,8 +5057,18 @@ $var = (new foo())->bar()->foo()[0][1];
 $var = (new foo())->bar()->foo()->baz();
 $var = (new $foo())->bar;
 $var = (new $bar->y())->x;
+(new SortOfLongClassName())
+    ->withALongMethodName()
+    ->andAnother()
+    ->toPushItPast80Chars();
+$asdf = (new SortOfLongClassName())
+    ->withALongMethodName()
+    ->andAnother()
+    ->toPushItPast80Chars();
 $var = (new foo())[0];
 $var = (new foo())[0]["string"];
+$var = (new Foo())::foo;
+$var = (new Foo())::$foo;
 $var = new $a->b();
 $var = new $a->b();
 $var = (new $a())->b();
@@ -5098,6 +5122,9 @@ printWidth: 80
 $var = new Foo();
 $var = (new Foo());
 $var = (new Foo())->c();
+new Foo->prop;
+new Foo->method();
+new Foo->$var;
 $var = (new class {
     public function log($msg)
     {
@@ -5113,8 +5140,16 @@ $var = ((((new foo())->bar())->foo())[0])[1];
 $var = (((new foo())->bar())->foo())->baz();
 $var = (new $foo())->bar;
 $var = (new $bar->y)->x;
+new SortOfLongClassName()->withALongMethodName()->andAnother()->toPushItPast80Chars();
+$asdf =
+new SortOfLongClassName()->withALongMethodName()
+    ->andAnother()->toPushItPast80Chars();
+
 $var = (new foo)[0];
 $var = (new foo)[0]['string'];
+
+$var = (new Foo)::foo;
+$var = (new Foo)::$foo;
 
 $var = new $a->b;
 $var = new $a->b();
@@ -5146,33 +5181,46 @@ new Translator(
 <?php
 $var = new Foo();
 $var = new Foo();
-$var = (new Foo())->c();
+$var = new Foo()->c();
+new Foo()->prop;
+new Foo()->method();
+new Foo()->$var;
 $var = new class {
     public function log($msg)
     {
         echo $msg;
     }
 };
-$var = (new foo())->bar();
-$var = (new foo())->bar()->foo();
-$var = (new foo())->bar()->foo();
-$var = (new foo())->bar()->foo();
-$var = (new foo())->bar()->foo()[0];
-$var = (new foo())->bar()->foo()[0][1];
-$var = (new foo())->bar()->foo()->baz();
-$var = (new $foo())->bar;
-$var = (new $bar->y())->x;
-$var = (new foo())[0];
-$var = (new foo())[0]["string"];
+$var = new foo()->bar();
+$var = new foo()->bar()->foo();
+$var = new foo()->bar()->foo();
+$var = new foo()->bar()->foo();
+$var = new foo()->bar()->foo()[0];
+$var = new foo()->bar()->foo()[0][1];
+$var = new foo()->bar()->foo()->baz();
+$var = new $foo()->bar;
+$var = new $bar->y()->x;
+new SortOfLongClassName()
+    ->withALongMethodName()
+    ->andAnother()
+    ->toPushItPast80Chars();
+$asdf = new SortOfLongClassName()
+    ->withALongMethodName()
+    ->andAnother()
+    ->toPushItPast80Chars();
+$var = new foo()[0];
+$var = new foo()[0]["string"];
+$var = new Foo()::foo;
+$var = new Foo()::$foo;
 $var = new $a->b();
 $var = new $a->b();
-$var = (new $a())->b();
-$var = (new $a())->b();
-(new class {})->foo;
-(new class {})->foo();
-(new class {})();
-(new class {})["foo"];
-$var = (new class {})->foo;
+$var = new $a()->b();
+$var = new $a()->b();
+new class {}->foo;
+new class {}->foo();
+new class {}();
+new class {}["foo"];
+$var = new class {}->foo;
 
 
 ================================================================================

--- a/tests/parens/__snapshots__/jsfmt.spec.mjs.snap
+++ b/tests/parens/__snapshots__/jsfmt.spec.mjs.snap
@@ -104,6 +104,111 @@ $var = [new stdClass()][0];
 ================================================================================
 `;
 
+exports[`array.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+array();
+(array());
+
+[];
+([]);
+
+$var = array();
+$var = (array());
+
+$var = [];
+$var = ([]);
+
+$var = array("1", "2", "3");
+$var = (array("1", "2", "3"));
+$var = array(array("1"), array("2"), array("3"));
+$var = (array(array("1"), array("2"), array("3")));
+$var = array((array("1")), (array("2")), (array("3")));
+$var = (array((array("1")), (array("2")), (array("3"))));
+
+$var = array("foo", "bar")();
+$var = (array("foo", "bar"))();
+$var = ((array("foo", "bar")))();
+
+$var = ["foo", "bar"]();
+$var = (["foo", "bar"])();
+$var = ((["foo", "bar"]))();
+
+$arr = [$var, $other_var];
+$arr = [($var), ($other_var)];
+$arr = [('key') => ($var), ('other-key') => ($other_var)];
+$arr = ([('key') => ($var), ('other-key') => ($other_var)]);
+
+[$var, $other_var] = $arr;
+[($var), ($other_var)] = $arr;
+[('key') => ($var), ('other-key') => ($other_var)] = $arr;
+
+$var = array(1, 2, 3)[1];
+$var = (array(1, 2, 3))[1];
+$var = [1, 2, 3][1];
+$var = ([1, 2, 3])[1];
+$var = array(new stdClass())[0];
+$var = (array((new stdClass())))[0];
+$var = [new stdClass()][0];
+$var = ([(new stdClass())])[0];
+
+=====================================output=====================================
+<?php
+
+[];
+[];
+
+[];
+[];
+
+$var = [];
+$var = [];
+
+$var = [];
+$var = [];
+
+$var = ["1", "2", "3"];
+$var = ["1", "2", "3"];
+$var = [["1"], ["2"], ["3"]];
+$var = [["1"], ["2"], ["3"]];
+$var = [["1"], ["2"], ["3"]];
+$var = [["1"], ["2"], ["3"]];
+
+$var = (["foo", "bar"])();
+$var = (["foo", "bar"])();
+$var = (["foo", "bar"])();
+
+$var = (["foo", "bar"])();
+$var = (["foo", "bar"])();
+$var = (["foo", "bar"])();
+
+$arr = [$var, $other_var];
+$arr = [$var, $other_var];
+$arr = ["key" => $var, "other-key" => $other_var];
+$arr = ["key" => $var, "other-key" => $other_var];
+
+[$var, $other_var] = $arr;
+[$var, $other_var] = $arr;
+["key" => $var, "other-key" => $other_var] = $arr;
+
+$var = [1, 2, 3][1];
+$var = [1, 2, 3][1];
+$var = [1, 2, 3][1];
+$var = [1, 2, 3][1];
+$var = [new stdClass()][0];
+$var = [new stdClass()][0];
+$var = [new stdClass()][0];
+$var = [new stdClass()][0];
+
+================================================================================
+`;
+
 exports[`assign.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]
@@ -318,9 +423,273 @@ switch ($i = 1) {
 ================================================================================
 `;
 
+exports[`assign.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+$var = 1;
+($var = 1);
+
+$var = $var;
+($var = $var);
+
+$var = $var = $var;
+$var = ($var = $var);
+($var = ($var = $var));
+
+$var = $var += 1;
+$var = ($var += 1);
+
+$var = ($var = 4) + 5;
+$var = ($var = ['key' => 'value']);
+
+($var = $var ? $var : function() { return 0; });
+
+for ($i = 1; $i <= 10; $i++) {
+    echo $i;
+}
+
+for (($i = 1); ($i <= 10); ($i++)) {
+    echo $i;
+}
+for (($i = 1), ($j = 0); ($i <= 10); ($j += $i), print ($i), ($i++));
+
+if ($a = 1) {}
+
+while ($var = 1) {}
+while ($var = current($array) !== FALSE) {}
+while (($var = current($array)) !== FALSE) {}
+
+$var = $var || $var = new MyClass();
+$var = $var || ($var = new MyClass());
+
+if (true) $var = $var;
+if (true) ($var = $var);
+if (true) { ($var = $var); } else if (false) ($var = $var);
+if (true) { ($var = $var); } else if (false) { ($var = $var); } else ($var = $var);
+
+if (true) {
+    $var = $var;
+    ($var = $var);
+}
+
+while ($i <= 10) $i = 1;
+while ($i <= 10) ($i = 1);
+
+do {
+    echo $i;
+} while ($i = 0);
+
+for ($i = 1; $i <= 10; $i++) $i = 1;
+for ($i = 1; $i <= 10; $i++) ($i = 1);
+
+foreach ($arr as &$value) $value = $value * 2;
+foreach ($arr as &$value) ($value = $value * 2);
+
+switch ($i = 1) {
+    case 0:
+        echo "i equals 0";
+        break;
+    case 1:
+        echo "i equals 1";
+        break;
+    case 2:
+        echo "i equals 2";
+        break;
+}
+
+switch (($i = 1)) {
+    case 0:
+        echo "i equals 0";
+        break;
+    case 1:
+        echo "i equals 1";
+        break;
+    case 2:
+        echo "i equals 2";
+        break;
+}
+
+=====================================output=====================================
+<?php
+
+$var = 1;
+$var = 1;
+
+$var = $var;
+$var = $var;
+
+$var = $var = $var;
+$var = $var = $var;
+$var = $var = $var;
+
+$var = $var += 1;
+$var = $var += 1;
+
+$var = ($var = 4) + 5;
+$var = $var = ["key" => "value"];
+
+$var = $var
+    ? $var
+    : function () {
+        return 0;
+    };
+
+for ($i = 1; $i <= 10; $i++) {
+    echo $i;
+}
+
+for ($i = 1; $i <= 10; $i++) {
+    echo $i;
+}
+for ($i = 1, $j = 0; $i <= 10; $j += $i, print $i, $i++);
+
+if ($a = 1) {
+}
+
+while ($var = 1) {
+}
+while ($var = current($array) !== false) {
+}
+while (($var = current($array)) !== false) {
+}
+
+$var = $var || ($var = new MyClass());
+$var = $var || ($var = new MyClass());
+
+if (true) {
+    $var = $var;
+}
+if (true) {
+    $var = $var;
+}
+if (true) {
+    $var = $var;
+} elseif (false) {
+    $var = $var;
+}
+if (true) {
+    $var = $var;
+} elseif (false) {
+    $var = $var;
+} else {
+    $var = $var;
+}
+
+if (true) {
+    $var = $var;
+    $var = $var;
+}
+
+while ($i <= 10) {
+    $i = 1;
+}
+while ($i <= 10) {
+    $i = 1;
+}
+
+do {
+    echo $i;
+} while ($i = 0);
+
+for ($i = 1; $i <= 10; $i++) {
+    $i = 1;
+}
+for ($i = 1; $i <= 10; $i++) {
+    $i = 1;
+}
+
+foreach ($arr as &$value) {
+    $value = $value * 2;
+}
+foreach ($arr as &$value) {
+    $value = $value * 2;
+}
+
+switch ($i = 1) {
+    case 0:
+        echo "i equals 0";
+        break;
+    case 1:
+        echo "i equals 1";
+        break;
+    case 2:
+        echo "i equals 2";
+        break;
+}
+
+switch ($i = 1) {
+    case 0:
+        echo "i equals 0";
+        break;
+    case 1:
+        echo "i equals 1";
+        break;
+    case 2:
+        echo "i equals 2";
+        break;
+}
+
+================================================================================
+`;
+
 exports[`assignref.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+$test = $var = $test;
+$test = ($var = $test);
+$test = $var = &$test;
+$test = ($var = &$test);
+
+$a = ($b = $var) + 5;
+$a = ($b = &$var) + 5;
+
+$a = ($b = $var) || 5;
+$a = ($b = &$var) || 5;
+
+if (($foo = &$bar) && count($foo) > 0) {}
+if (($foo = &test1()) && test2($foo) > 0) {}
+
+call(($a =& $b));
+
+=====================================output=====================================
+<?php
+
+$test = $var = $test;
+$test = $var = $test;
+$test = $var = &$test;
+$test = $var = &$test;
+
+$a = ($b = $var) + 5;
+$a = $b = &$var + 5;
+
+$a = ($b = $var) || 5;
+$a = $b = &$var || 5;
+
+if ($foo = &$bar && count($foo) > 0) {
+}
+if ($foo = &test1() && test2($foo) > 0) {
+}
+
+call($a = &$b);
+
+================================================================================
+`;
+
+exports[`assignref.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -1133,9 +1502,801 @@ $result = 2 ** ($number - 1);
 ================================================================================
 `;
 
+exports[`bin.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+$var = 1;
+($var = 1);
+$var = $var = 1;
+$var = ($var = 1);
+($var = $var = 1);
+($var = ($var = 1));
+$var = $var = $var = $var;
+$var = $var = ($var = $var);
+$var = ($var = $var = $var);
+$var = ($var = ($var = $var));
+($var = ($var = ($var = $var)));
+
+$var = $var++;
+$var = ($var++);
+$var = ++$var;
+$var = (++$var);
+
+$var = $var--;
+$var = ($var--);
+$var = --$var;
+$var = (--$var);
+
+$var = ~$var;
+$var = (~$var);
+
+$var = !$var;
+$var = (!$var);
+
+$var = $var += 10;
+$var = ($var += 10);
+
+$var = 10 + 20 + 30;
+$var = (10 + 20) + 30;
+$var = 10 + (20 + 30);
+
+$var = '10' . '20' . '30';
+$var = ('10' . '20') . '30';
+$var = '10' . ('20' . '30');
+
+$var = 10 + 20 % 30;
+$var = (10 + 20) % 30;
+$var = 10 + (20 % 30);
+
+$var = 10 ** 20 ** 30;
+$var = (10 ** 20) ** 30;
+$var = 10 ** (20 ** 30);
+
+$var = (10 == 20) == 30;
+$var = 10 == (20 == 30);
+
+$var = (10 === 20) === 30;
+$var = 10 === (20 === 30);
+
+$var = 10 * 20 % 30;
+$var = (10 * 20) % 30;
+$var = 10 * (20 % 30);
+
+$var = 10 * 20 / 30;
+$var = (10 * 20) / 30;
+$var = 10 * (20 / 30);
+
+$var = 10 / 20 * 30;
+$var = (10 / 20) * 30;
+$var = 10 / (20 * 30);
+
+$var = 10 << 20 << 30;
+$var = (10 << 20) << 30;
+$var = 10 << (20 << 30);
+
+$var = 10 >> 20 >> 30;
+$var = (10 >> 20) >> 30;
+$var = 10 >> (20 >> 30);
+
+$var = 10 ^ 20 ^ 30;
+$var = (10 ^ 20) ^ 30;
+$var = 10 ^ (20 ^ 30);
+
+$var = 10 | 20 | 30;
+$var = (10 | 20) | 30;
+$var = 10 | (20 | 30);
+
+$var = false || true;
+$var = (false || true);
+$var = false or true;
+$var = (false or true);
+$var = true && false;
+$var = (true && false);
+$var = true and false;
+$var = (true and false);
+
+$var = $var || $var();
+$var = ($var || $var)();
+$var = $var && $var();
+$var = ($var && $var)();
+$var = call($var || $var);
+$var = call(($var || $var));
+$var = call($var && $var);
+$var = call(($var && $var));
+
+$var = +($var || $var);
+$var = -($var || $var);
+$var = ~($var || $var);
+
+$var = ($var || $var)->foo;
+$var = ($var || $var)->foo();
+$var = ($var || $var)[1];
+
+$var = $var || $var && $var;
+$var = ($var || $var) && $var;
+$var = $var || ($var && $var);
+
+$var = $var & ($var || 'test');
+$var = ($var || 'test') & $var;
+$var = $var & ($var . 'test');
+$var = ($var . 'test') & $var;
+$var = ($var & $var) || 'test';
+$var = $var || ('test' & $var);
+
+$var = ($var || $var) % 100;
+$var = ($var + $var) % 100;
+$var = 100 % ($var || $var);
+$var = 100 % ($var + $var);
+$var = $var || ($var % 100);
+$var = $var + ($var % 100);
+$var = (100 % $var) || $var;
+$var = (100 % $var) + $var;
+
+$var = ($var + $var) >> 1;
+$var = (($var - 1) >> $var) & $var;
+$var = $var > $var ? 0 : ($var - $var) >> $var;
+$var = (($var - $var) >> $var) + 1;
+
+if ($var < 1 << ($var + $var)) {}
+
+$var = $var < $var ? 0 : ((($var - 1) >> $var) << $var);
+$var = 1 - (2 * ($var[3] >> 7));
+$var = ((($var[3] << 1) & 0xff) | ($var[2] >> 7)) - 127;
+$var = (($var[2] & 0x7f) << 16) | ($var[1] << 8) | $var[0];
+
+$var = 2 / 3 * 10 / 2 + 2;
+
+$var = (($var / $var) * $var - $var / 2) * call($var);
+$var = (($var / $var) * $var - $var / 2) * call($var);
+
+$var = $var % 10 - 5;
+$var = $var * $var % 10;
+$var = $var % 10 > 5;
+$var = $var % 10 == 0;
+
+$var = $var + $var / $var;
+$var = $var / $var + $var;
+
+$var = $var * $var % $var;
+$var = $var / $var % $var;
+$var = $var % $var * $var;
+$var = $var % $var / $var;
+
+$var = $var % $var % $var;
+
+$var = $var << $var >> $var;
+$var = $var >> $var << $var;
+$var = $var >> $var >> $var;
+$var = $var + $var >> $var;
+$var = ($var + $var) >> $var;
+$var = $var + ($var >> $var);
+
+$var = $var | $var & $var;
+$var = $var & $var | $var;
+$var = $var ^ $var ^ $var;
+$var = $var & $var & $var;
+$var = $var | $var | $var;
+$var = $var & $var >> $var;
+$var = $var << $var | $var;
+
+$var = $var ? 'foo' : 'bar' . 'test';
+$var = ($var ? 'foo' : 'bar') . 'test';
+$var = $var ? 'foo' : ('bar' . 'test');
+
+call(($var + $var));
+
+$var = call(($var + $var));
+
+$var = $var + $var ** 2;
+$var = ($var + $var) ** 2;
+$var = $var + ($var ** 2);
+$var = (+$var) ** 2;
+$var = +$var ** 2;
+
+$var = $foo instanceof Foo;
+$var = $foo instanceof Foo || $foo instanceof Foo;
+$var = ($foo instanceof Foo) || ($foo instanceof Foo);
+$var = (($foo) instanceof Foo);
+
+$var = !$var;
+$var = !($var);
+$var = (!($var));
+$var = !!$var;
+$var = !!($var);
+$var = !(!($var));
+$var = (!(!($var)));
+$var = !!!$var;
+$var = !!!($var);
+$var = !!(!($var));
+$var = !(!(!($var)));
+$var = (!(!(!($var))));
+
+$var = !$var || !$var;
+$var = (!($var) || !($var));
+$var = !(!($var) || !($var));
+
+$var = $var + $var * $var;
+$var = ($var + $var) * $var;
+
+$var = @foo() || @foo();
+$var = @(foo() || foo());
+
+($var += ($var += ($var += $var)));
+($var -= ($var -= ($var -= $var)));
+($var *= ($var *= ($var *= $var)));
+($var **= ($var **= ($var **= $var)));
+($var /= ($var /= ($var /= $var)));
+($var .= ($var .= ($var .= $var)));
+($var %= ($var %= ($var %= $var)));
+($var &= ($var &= ($var &= $var)));
+($var |= ($var |= ($var |= $var)));
+($var ^= ($var ^= ($var ^= $var)));
+($var <<= ($var <<= ($var <<= $var)));
+($var >>= ($var >>= ($var >>= $var)));
+
+$var = $var | $var | $var;
+$var = $var | ($var | $var);
+$var = ($var | $var) | $var;
+$var = $var & $var & $var;
+$var = $var & ($var & $var);
+$var = ($var & $var) & $var;
+
+$var = $var ^ $var | $var;
+$var = ($var ^ $var) | $var;
+$var = $var | $var ^ $var;
+$var = $var | ($var ^ $var);
+$var = ($var | $var) ^ $var;
+
+$var = $var & $var | $var;
+$var = ($var & $var) | $var;
+$var = $var | $var & $var;
+$var = $var | ($var & $var);
+$var = ($var | $var) & $var;
+
+$var = $var == $var || false;
+$var = ($var == $var) || false;
+$var = $var == ($var || false);
+
+$var = false || $var == $var;
+$var = false || ($var == $var);
+$var = ($var || false) == $var;
+
+$var = 'string' . true ? '1' : '2';
+$var = 'string' . (true ? '1' : '2');
+
+$var = 'string' . (100 + 100);
+$var = (100 + 100) . 'string';
+$var = 'string' . ($var || 100);
+$var = ($var || 100) . 'string';
+$var = 'string' . ($var * 100);
+$var = ($var * 100) . 'string';
+$var = 'string' . !$var;
+$var = !$var . 'string';
+$var = 'string' . ($var | 100);
+$var = ($var | 100) . 'string';
+
+$var = $var . $var % $var;
+$var = ($var . $var) % $var;
+$var = $var % $var . $var;
+$var = $var % ($var . $var);
+
+$var = '100' - '100' - '100';
+$var = ('100' - '100') - '100';
+$var = '100' - ('100' - '100');
+
+if (false || true) {};
+if ((false || true)) {};
+if (false or true) {};
+if ((false or true)) {};
+if (true && false) {};
+if ((true && false)) {};
+if (true and false) {};
+if ((true and false)) {};
+
+if (!$foo or $bar == -1) {}
+if ((!$foo or $bar == -1)) {}
+if ((!$foo or $bar) == -1) {}
+if (!$foo or ($bar == -1)) {}
+
+do {} while ($foo and $bar);
+while ($foo or $bar < 10) {}
+for ($foo or $bar;;) {}
+switch ($foo or $bar) {}
+
+$a ** $b ** $c;
+($a ** $b) ** $c;
+$a->b ** $c;
+(-$a) ** $b;
+$a ** -$b;
+-($a**$b);
+($a * $b) ** $c;
+$a ** ($b * $c);
+($a % $b) ** $c;
+
+$var = $var + $var ?? '';
+$var = $var + ($var ?? '');
+$var = ($var + $var) ?? '';
+$var = $var ?? null + 1;
+$var = ($var ?? null) + 1;
+$var = $var && ($var ?? true);
+$var = ($var ?? true) && $var;
+$var = $var && ($var ?? null) === true;
+$var = ($var ?? null) === true && $var;
+
+$findAll = $cachesNames === [];
+$findAll = ($cachesNames === []);
+
+$isNamespaced = strpos($fixture, '\\\\') !== false;
+$isNamespaced = (strpos($fixture, '\\\\') !== false);
+
+$var = $a['apply_time'] > $b['apply_time'] ? -1 : +1;
+$var = ($a['apply_time'] > $b['apply_time']) ? -1 : +1;
+
+$var = $page > 0 || $page == 0 && $this->forcePageParam;
+$var = $page > 0 || ($page == 0 && $this->forcePageParam);
+
+@foo() || @foo();
+(@foo()) || (@foo());
+$var = @foo() || @foo();
+$var = (@foo() || @foo());
+
+@$i / 0;
+@($i) / 0;
+
+$var = "a" . (@$b ? 'bar' : "baz");
+
+$a = (false && foo());
+$b = (true  || foo());
+$c = (false and foo());
+$d = (true  or  foo());
+
+$f = false or true;
+$h = true and false;
+
+$my_file = call('non_existent_file') or die("Failed opening file: error was '$php_errormsg'");
+($my_file = call('non_existent_file')) or die("Failed opening file: error was '$php_errormsg'");
+
+$my_file = call('non_existent_file') and die("Failed opening file: error was '$php_errormsg'");
+($my_file = call('non_existent_file')) and die("Failed opening file: error was '$php_errormsg'");
+
+$var = $obj->foo ?? "default";
+$var = $foo ? $bar ?? $foo : $baz;
+$var = $foo ?? ($bar ?? $baz);
+$var = ($foo ?? $baz) || $baz;
+$var = $foo ?? $baz || $baz;
+$var = ($foo && $baz) ?? $baz;
+$var = $foo && ($baz ?? $baz);
+
+$result = 2 ** $number - 1;
+$result = (2 ** $number) - 1;
+$result = 2 ** ($number - 1);
+
+=====================================output=====================================
+<?php
+
+$var = 1;
+$var = 1;
+$var = $var = 1;
+$var = $var = 1;
+$var = $var = 1;
+$var = $var = 1;
+$var = $var = $var = $var;
+$var = $var = $var = $var;
+$var = $var = $var = $var;
+$var = $var = $var = $var;
+$var = $var = $var = $var;
+
+$var = $var++;
+$var = $var++;
+$var = ++$var;
+$var = ++$var;
+
+$var = $var--;
+$var = $var--;
+$var = --$var;
+$var = --$var;
+
+$var = ~$var;
+$var = ~$var;
+
+$var = !$var;
+$var = !$var;
+
+$var = $var += 10;
+$var = $var += 10;
+
+$var = 10 + 20 + 30;
+$var = 10 + 20 + 30;
+$var = 10 + (20 + 30);
+
+$var = "10" . "20" . "30";
+$var = "10" . "20" . "30";
+$var = "10" . ("20" . "30");
+
+$var = 10 + (20 % 30);
+$var = (10 + 20) % 30;
+$var = 10 + (20 % 30);
+
+$var = 10 ** (20 ** 30);
+$var = (10 ** 20) ** 30;
+$var = 10 ** (20 ** 30);
+
+$var = (10 == 20) == 30;
+$var = 10 == (20 == 30);
+
+$var = (10 === 20) === 30;
+$var = 10 === (20 === 30);
+
+$var = (10 * 20) % 30;
+$var = (10 * 20) % 30;
+$var = 10 * (20 % 30);
+
+$var = (10 * 20) / 30;
+$var = (10 * 20) / 30;
+$var = 10 * (20 / 30);
+
+$var = (10 / 20) * 30;
+$var = (10 / 20) * 30;
+$var = 10 / (20 * 30);
+
+$var = (10 << 20) << 30;
+$var = (10 << 20) << 30;
+$var = 10 << (20 << 30);
+
+$var = (10 >> 20) >> 30;
+$var = (10 >> 20) >> 30;
+$var = 10 >> (20 >> 30);
+
+$var = 10 ^ 20 ^ 30;
+$var = 10 ^ 20 ^ 30;
+$var = 10 ^ (20 ^ 30);
+
+$var = 10 | 20 | 30;
+$var = 10 | 20 | 30;
+$var = 10 | (20 | 30);
+
+$var = false || true;
+$var = false || true;
+($var = false) or true;
+$var = (false or true);
+$var = true && false;
+$var = true && false;
+($var = true) and false;
+$var = (true and false);
+
+$var = $var || $var();
+$var = ($var || $var)();
+$var = $var && $var();
+$var = ($var && $var)();
+$var = call($var || $var);
+$var = call($var || $var);
+$var = call($var && $var);
+$var = call($var && $var);
+
+$var = +($var || $var);
+$var = -($var || $var);
+$var = ~($var || $var);
+
+$var = ($var || $var)->foo;
+$var = ($var || $var)->foo();
+$var = ($var || $var)[1];
+
+$var = $var || ($var && $var);
+$var = ($var || $var) && $var;
+$var = $var || ($var && $var);
+
+$var = $var & ($var || "test");
+$var = ($var || "test") & $var;
+$var = $var & ($var . "test");
+$var = ($var . "test") & $var;
+$var = $var & $var || "test";
+$var = $var || "test" & $var;
+
+$var = ($var || $var) % 100;
+$var = ($var + $var) % 100;
+$var = 100 % ($var || $var);
+$var = 100 % ($var + $var);
+$var = $var || $var % 100;
+$var = $var + ($var % 100);
+$var = 100 % $var || $var;
+$var = (100 % $var) + $var;
+
+$var = $var + $var >> 1;
+$var = ($var - 1 >> $var) & $var;
+$var = $var > $var ? 0 : $var - $var >> $var;
+$var = ($var - $var >> $var) + 1;
+
+if ($var < 1 << $var + $var) {
+}
+
+$var = $var < $var ? 0 : ($var - 1 >> $var) << $var;
+$var = 1 - 2 * ($var[3] >> 7);
+$var = ((($var[3] << 1) & 0xff) | ($var[2] >> 7)) - 127;
+$var = (($var[2] & 0x7f) << 16) | ($var[1] << 8) | $var[0];
+
+$var = ((2 / 3) * 10) / 2 + 2;
+
+$var = (($var / $var) * $var - $var / 2) * call($var);
+$var = (($var / $var) * $var - $var / 2) * call($var);
+
+$var = ($var % 10) - 5;
+$var = ($var * $var) % 10;
+$var = $var % 10 > 5;
+$var = $var % 10 == 0;
+
+$var = $var + $var / $var;
+$var = $var / $var + $var;
+
+$var = ($var * $var) % $var;
+$var = ($var / $var) % $var;
+$var = ($var % $var) * $var;
+$var = ($var % $var) / $var;
+
+$var = ($var % $var) % $var;
+
+$var = ($var << $var) >> $var;
+$var = ($var >> $var) << $var;
+$var = ($var >> $var) >> $var;
+$var = $var + $var >> $var;
+$var = $var + $var >> $var;
+$var = $var + ($var >> $var);
+
+$var = $var | ($var & $var);
+$var = ($var & $var) | $var;
+$var = $var ^ $var ^ $var;
+$var = $var & $var & $var;
+$var = $var | $var | $var;
+$var = $var & ($var >> $var);
+$var = ($var << $var) | $var;
+
+$var = $var ? "foo" : "bar" . "test";
+$var = ($var ? "foo" : "bar") . "test";
+$var = $var ? "foo" : "bar" . "test";
+
+call($var + $var);
+
+$var = call($var + $var);
+
+$var = $var + $var ** 2;
+$var = ($var + $var) ** 2;
+$var = $var + $var ** 2;
+$var = (+$var) ** 2;
+$var = (+$var) ** 2;
+
+$var = $foo instanceof Foo;
+$var = $foo instanceof Foo || $foo instanceof Foo;
+$var = $foo instanceof Foo || $foo instanceof Foo;
+$var = $foo instanceof Foo;
+
+$var = !$var;
+$var = !$var;
+$var = !$var;
+$var = !!$var;
+$var = !!$var;
+$var = !!$var;
+$var = !!$var;
+$var = !!!$var;
+$var = !!!$var;
+$var = !!!$var;
+$var = !!!$var;
+$var = !!!$var;
+
+$var = !$var || !$var;
+$var = !$var || !$var;
+$var = !(!$var || !$var);
+
+$var = $var + $var * $var;
+$var = ($var + $var) * $var;
+
+$var = @foo() || @foo();
+$var = @(foo() || foo());
+
+$var += $var += $var += $var;
+$var -= $var -= $var -= $var;
+$var *= $var *= $var *= $var;
+$var **= $var **= $var **= $var;
+$var /= $var /= $var /= $var;
+$var .= $var .= $var .= $var;
+$var %= $var %= $var %= $var;
+$var &= $var &= $var &= $var;
+$var |= $var |= $var |= $var;
+$var ^= $var ^= $var ^= $var;
+$var <<= $var <<= $var <<= $var;
+$var >>= $var >>= $var >>= $var;
+
+$var = $var | $var | $var;
+$var = $var | ($var | $var);
+$var = $var | $var | $var;
+$var = $var & $var & $var;
+$var = $var & ($var & $var);
+$var = $var & $var & $var;
+
+$var = ($var ^ $var) | $var;
+$var = ($var ^ $var) | $var;
+$var = $var | ($var ^ $var);
+$var = $var | ($var ^ $var);
+$var = ($var | $var) ^ $var;
+
+$var = ($var & $var) | $var;
+$var = ($var & $var) | $var;
+$var = $var | ($var & $var);
+$var = $var | ($var & $var);
+$var = ($var | $var) & $var;
+
+$var = $var == $var || false;
+$var = $var == $var || false;
+$var = $var == ($var || false);
+
+$var = false || $var == $var;
+$var = false || $var == $var;
+$var = ($var || false) == $var;
+
+$var = "string" . true ? "1" : "2";
+$var = "string" . (true ? "1" : "2");
+
+$var = "string" . (100 + 100);
+$var = 100 + 100 . "string";
+$var = "string" . ($var || 100);
+$var = ($var || 100) . "string";
+$var = "string" . $var * 100;
+$var = $var * 100 . "string";
+$var = "string" . !$var;
+$var = !$var . "string";
+$var = "string" . ($var | 100);
+$var = ($var | 100) . "string";
+
+$var = $var . $var % $var;
+$var = ($var . $var) % $var;
+$var = $var % $var . $var;
+$var = $var % ($var . $var);
+
+$var = "100" - "100" - "100";
+$var = "100" - "100" - "100";
+$var = "100" - ("100" - "100");
+
+if (false || true) {
+}
+if (false || true) {
+}
+if (false or true) {
+}
+if (false or true) {
+}
+if (true && false) {
+}
+if (true && false) {
+}
+if (true and false) {
+}
+if (true and false) {
+}
+
+if (!$foo or $bar == -1) {
+}
+if (!$foo or $bar == -1) {
+}
+if ((!$foo or $bar) == -1) {
+}
+if (!$foo or $bar == -1) {
+}
+
+do {
+} while ($foo and $bar);
+while ($foo or $bar < 10) {
+}
+for ($foo or $bar; ; ) {
+}
+switch ($foo or $bar) {
+}
+
+$a ** ($b ** $c);
+($a ** $b) ** $c;
+$a->b ** $c;
+(-$a) ** $b;
+$a ** -$b;
+-($a ** $b);
+($a * $b) ** $c;
+$a ** ($b * $c);
+($a % $b) ** $c;
+
+$var = $var + $var ?? "";
+$var = $var + ($var ?? "");
+$var = $var + $var ?? "";
+$var = $var ?? null + 1;
+$var = ($var ?? null) + 1;
+$var = $var && ($var ?? true);
+$var = ($var ?? true) && $var;
+$var = $var && ($var ?? null) === true;
+$var = ($var ?? null) === true && $var;
+
+$findAll = $cachesNames === [];
+$findAll = $cachesNames === [];
+
+$isNamespaced = strpos($fixture, "\\\\") !== false;
+$isNamespaced = strpos($fixture, "\\\\") !== false;
+
+$var = $a["apply_time"] > $b["apply_time"] ? -1 : +1;
+$var = $a["apply_time"] > $b["apply_time"] ? -1 : +1;
+
+$var = $page > 0 || ($page == 0 && $this->forcePageParam);
+$var = $page > 0 || ($page == 0 && $this->forcePageParam);
+
+@foo() || @foo();
+@foo() || @foo();
+$var = @foo() || @foo();
+$var = @foo() || @foo();
+
+@$i / 0;
+@$i / 0;
+
+$var = "a" . (@$b ? "bar" : "baz");
+
+$a = false && foo();
+$b = true || foo();
+$c = (false and foo());
+$d = (true or foo());
+
+($f = false) or true;
+($h = true) and false;
+
+($my_file = call("non_existent_file")) or
+    die("Failed opening file: error was '$php_errormsg'");
+($my_file = call("non_existent_file")) or
+    die("Failed opening file: error was '$php_errormsg'");
+
+($my_file = call("non_existent_file")) and
+    die("Failed opening file: error was '$php_errormsg'");
+($my_file = call("non_existent_file")) and
+    die("Failed opening file: error was '$php_errormsg'");
+
+$var = $obj->foo ?? "default";
+$var = $foo ? $bar ?? $foo : $baz;
+$var = $foo ?? ($bar ?? $baz);
+$var = ($foo ?? $baz) || $baz;
+$var = $foo ?? $baz || $baz;
+$var = $foo && $baz ?? $baz;
+$var = $foo && ($baz ?? $baz);
+
+$result = 2 ** $number - 1;
+$result = 2 ** $number - 1;
+$result = 2 ** ($number - 1);
+
+================================================================================
+`;
+
 exports[`block.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+function foo() {
+    ($a->c());
+}
+
+=====================================output=====================================
+<?php
+
+function foo()
+{
+    $a->c();
+}
+
+================================================================================
+`;
+
+exports[`block.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -1190,9 +2351,163 @@ break 2;
 ================================================================================
 `;
 
+exports[`break.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+break;
+break 1;
+break (1);
+break ((1));
+break (((1)));
+break 2;
+break (2);
+break ((2));
+break (((2)));
+
+=====================================output=====================================
+<?php
+
+break;
+break;
+break;
+break;
+break;
+break 2;
+break 2;
+break 2;
+break 2;
+
+================================================================================
+`;
+
 exports[`call.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+call();
+(call());
+
+$var = call();
+$var = (call());
+$var = call()();
+$var = (call())();
+$var = (call()());
+$var = ((call())());
+
+$var = $foo->call();
+$var = ($foo)->call();
+$var = ($foo->call());
+$var = $foo->call()->call();
+$var = ($foo)->call()->call();
+$var = (($foo)->call())->call();
+$var = ((($foo)->call())->call());
+
+$var = call((call()));
+$var = call(...(call()));
+$var = (call((call())));
+$var = (call((call()), (call())));
+
+$var = $func();
+$var = ($func)();
+$var = ($func());
+$var = (($func)());
+
+$var = $this->$name();
+$var = ($this)->$name();
+$var = ($this->$name());
+$var = (($this)->$name());
+
+$var = Foo::call();
+$var = (Foo::call());
+
+$var = (array("Foo", "bar"))();
+$var = (array(new Foo, "baz"))();
+$var = ((string) 1234)();
+$var = "Foo::bar"();
+$var = ("Foo::bar")();
+
+call(($a), (($b)), ((($c))));
+call($a = $b);
+call(($a = $b));
+call($a = new Foo());
+call(($a = new Foo()));
+call($a = (new Foo()));
+call(($a = (new Foo())));
+$foo->call(($a = (new Foo())));
+Foo::call(($a = (new Foo())));
+
+=====================================output=====================================
+<?php
+
+call();
+call();
+
+$var = call();
+$var = call();
+$var = call()();
+$var = call()();
+$var = call()();
+$var = call()();
+
+$var = $foo->call();
+$var = $foo->call();
+$var = $foo->call();
+$var = $foo->call()->call();
+$var = $foo->call()->call();
+$var = $foo->call()->call();
+$var = $foo->call()->call();
+
+$var = call(call());
+$var = call(...call());
+$var = call(call());
+$var = call(call(), call());
+
+$var = $func();
+$var = $func();
+$var = $func();
+$var = $func();
+
+$var = $this->$name();
+$var = $this->$name();
+$var = $this->$name();
+$var = $this->$name();
+
+$var = Foo::call();
+$var = Foo::call();
+
+$var = (["Foo", "bar"])();
+$var = ([new Foo(), "baz"])();
+$var = ((string) 1234)();
+$var = ("Foo::bar")();
+$var = ("Foo::bar")();
+
+call($a, $b, $c);
+call($a = $b);
+call($a = $b);
+call($a = new Foo());
+call($a = new Foo());
+call($a = new Foo());
+call($a = new Foo());
+$foo->call($a = new Foo());
+Foo::call($a = new Foo());
+
+================================================================================
+`;
+
+exports[`call.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -1509,9 +2824,290 @@ $timeout =
 ================================================================================
 `;
 
+exports[`cast.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+(int) '1';
+( int ) '1';
+((int) '1');
+((int) ('1'));
+
+$var = (int) '1';
+$var = ((int) '1');
+$var = ((int) ('1'));
+$var = ((bool) (2.3e5));
+$var = (object) [];
+$var = (object) ([]);
+$var = ((object) ([]));
+$var = ((object) (array('1' => 'foo')));
+$var = ((object) (['1' => 'foo']));
+$var = ((object) 'ciao')->scalar;
+$var = ((object) array('test'))->{'0'};
+$var = (((object) array('test'))->{'0'});
+$var = (array) new B();
+$var = (array) (new B());
+$var = ((array) (new B()));
+$var = ((array) (new B()))['foo'];
+$var = ((string) 1234)[1];
+$var = ((string) 123)();
+$var = ((string) (123))();
+$var = "test"[0];
+$var = (array) "test"[0];
+$var = ((array) "test")[0];
+$var = [(int) 'key' => (int) '1'];
+$var = [((int) 'key') => ((int) '1')];
+$var = ([((int) 'key') => ((int) '1')]);
+$var = (int) $raw['data'] + $value;
+$var = ((int) $raw['data']) + $value;
+$var = (bool) $var ? 1 : 2;
+$var = (bool) ($var ? 1 : 2);
+$var = (bool) $var + 1 ? 1 : 2;
+$var = ((bool) $var) + 1 ? 1 : 2;
+$var = (bool) ($var + 1) ? 1 : 2;
+$var = ((bool) $var) ? 1 : 2;
+$var = ((bool) $var) ? (bool) 1 :  (bool) 2;
+$var = ((bool) $var) ? ((bool) 1) :  ((bool) 2);
+$var = ((bool) $var) ? (bool) 1 + 2 :  (bool) 2 + 3;
+$var = ((bool) $var) ? ((bool) 1 + 2) :  ((bool) 2 + 3);
+$var = ((bool) $var) ? (bool) $var ? 1 : 2 :  (bool) $var ? 1 : 2;
+$var = ((bool) $var) ? ((bool) $var) ? 1 : 2 :  ((bool) $var) ? 1 : 2;
+$var = ((bool) $var) ? (bool) ($var ? 1 : 2) :  (bool) ($var ? 1 : 2);
+$var = (bool) ($var ? (bool) ($var ? 1 : 2) :  (bool) ($var ? 1 : 2));
+$var = (bool) $var->foo;
+$var = (bool) ($var->foo);
+$var = ((bool) $var->foo);
+$var = ((object) $var)->foo;
+$var = ((object) $var)[0];
+$var = (int) 'test' + (int) 'test';
+$var = ((int) 'test') + ((int) 'test');
+$var = ((int) 'test') * ((int) 'test');
+$var = ((int) 'test') | ((int) 'test');
+$var = ((int) 'test') % ((int) 'test');
+$var = @((int) 'test');
+$var = @((int) call());
+$var = (int) (int) 1;
+$var = (int) ((int) 1);
+$var = call((int) $var, (int) call(), (int) $minutes * 60);
+$var = call(((int) $var), ((int) call()), (int) ($minutes * 60));
+$var = $var + (int) $minutes * 60;
+$var = $var + (int) ($minutes * 60);
+
+return (int) $var;
+return ((int) $var);
+
+if ((int) 1 === 1) {}
+if (1 === (int) 1) {}
+if (((int) 1) === 1) {}
+if (1 === ((int) 1)) {}
+if ((int) 1 === (int) 1) {}
+if (((int) 1) === (int) 1) {}
+if ((int) 1 === ((int) 1)) {}
+if (((int) (1)) === ((int) 1)) {}
+
+$var = (bool) call();
+$var = $var || (bool) call();
+$var = (bool) call() || $var;
+
+$var = (int) $var === 1;
+$var = ((int) $var) === 1;
+$var = (int) ($var === 1);
+
+$this->apc->put($this->prefix.$key, $value, (int) ($minutes * 60));
+
+$timeout = (int) ($server->timeout / 1000) + (($server->timeout % 1000 > 0) ? 1 : 0);
+
+=====================================output=====================================
+<?php
+
+(int) "1";
+(int) "1";
+(int) "1";
+(int) "1";
+
+$var = (int) "1";
+$var = ((int) "1");
+$var = ((int) "1");
+$var = ((bool) 2.3e5);
+$var = (object) [];
+$var = (object) [];
+$var = ((object) []);
+$var = ((object) ["1" => "foo"]);
+$var = ((object) ["1" => "foo"]);
+$var = ((object) "ciao")->scalar;
+$var = ((object) ["test"])->{'0'};
+$var = ((object) ["test"])->{'0'};
+$var = (array) new B();
+$var = (array) new B();
+$var = ((array) new B());
+$var = ((array) new B())["foo"];
+$var = ((string) 1234)[1];
+$var = ((string) 123)();
+$var = ((string) 123)();
+$var = "test"[0];
+$var = (array) "test"[0];
+$var = ((array) "test")[0];
+$var = [(int) "key" => (int) "1"];
+$var = [((int) "key") => ((int) "1")];
+$var = [((int) "key") => ((int) "1")];
+$var = (int) $raw["data"] + $value;
+$var = ((int) $raw["data"]) + $value;
+$var = (bool) $var ? 1 : 2;
+$var = (bool) ($var ? 1 : 2);
+$var = (bool) $var + 1 ? 1 : 2;
+$var = ((bool) $var) + 1 ? 1 : 2;
+$var = (bool) ($var + 1) ? 1 : 2;
+$var = ((bool) $var) ? 1 : 2;
+$var = ((bool) $var) ? (bool) 1 : (bool) 2;
+$var = ((bool) $var) ? ((bool) 1) : ((bool) 2);
+$var = ((bool) $var) ? (bool) 1 + 2 : (bool) 2 + 3;
+$var = ((bool) $var) ? (bool) 1 + 2 : (bool) 2 + 3;
+$var = (((bool) $var) ? ((bool) $var ? 1 : 2) : (bool) $var) ? 1 : 2;
+$var = (((bool) $var) ? (((bool) $var) ? 1 : 2) : ((bool) $var)) ? 1 : 2;
+$var = ((bool) $var) ? (bool) ($var ? 1 : 2) : (bool) ($var ? 1 : 2);
+$var = (bool) ($var ? (bool) ($var ? 1 : 2) : (bool) ($var ? 1 : 2));
+$var = (bool) $var->foo;
+$var = (bool) $var->foo;
+$var = ((bool) $var->foo);
+$var = ((object) $var)->foo;
+$var = ((object) $var)[0];
+$var = (int) "test" + (int) "test";
+$var = ((int) "test") + ((int) "test");
+$var = ((int) "test") * ((int) "test");
+$var = ((int) "test") | ((int) "test");
+$var = ((int) "test") % ((int) "test");
+$var = @((int) "test");
+$var = @((int) call());
+$var = (int) (int) 1;
+$var = (int) ((int) 1);
+$var = call((int) $var, (int) call(), (int) $minutes * 60);
+$var = call(((int) $var), ((int) call()), (int) ($minutes * 60));
+$var = $var + (int) $minutes * 60;
+$var = $var + (int) ($minutes * 60);
+
+return (int) $var;
+return (int) $var;
+
+if ((int) 1 === 1) {
+}
+if (1 === (int) 1) {
+}
+if (((int) 1) === 1) {
+}
+if (1 === ((int) 1)) {
+}
+if ((int) 1 === (int) 1) {
+}
+if (((int) 1) === (int) 1) {
+}
+if ((int) 1 === ((int) 1)) {
+}
+if (((int) 1) === ((int) 1)) {
+}
+
+$var = (bool) call();
+$var = $var || (bool) call();
+$var = (bool) call() || $var;
+
+$var = (int) $var === 1;
+$var = ((int) $var) === 1;
+$var = (int) ($var === 1);
+
+$this->apc->put($this->prefix . $key, $value, (int) ($minutes * 60));
+
+$timeout =
+    (int) ($server->timeout / 1000) + ($server->timeout % 1000 > 0 ? 1 : 0);
+
+================================================================================
+`;
+
 exports[`clone.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+clone $a;
+(clone $a);
+
+$var = clone $a;
+$var = clone $a();
+$var = (clone $a)();
+$var = (clone $a);
+$var = (clone $a)->foo;
+$var = (clone $a->foo);
+$var = (clone $a)->foo();
+
+$var = (clone foo())->bar()->foo();
+$var = ((clone foo())->bar())->foo();
+$var = (((clone foo())->bar())->foo());
+$var = (((clone foo())->bar())->foo())[0];
+$var = ((((clone foo())->bar())->foo())[0])[1];
+$var = (((clone foo())->bar())->foo())->baz();
+$var = (clone $foo())->bar;
+$var = (clone $bar->y)->x;
+$var = (clone $foo)[0];
+$var = (clone $foo)[0]['string'];
+
+$var = clone $a->b;
+$var = clone $a->b();
+$var = (clone $a)->b();
+$var = ((clone $a)->b());
+
+$var = (clone ($var));
+$var = (clone($var));
+$var = (clone($var->foo));
+$var = (clone($var->foo))->foo;
+
+=====================================output=====================================
+<?php
+
+clone $a;
+clone $a;
+
+$var = clone $a;
+$var = clone $a();
+$var = (clone $a)();
+$var = clone $a;
+$var = (clone $a)->foo;
+$var = clone $a->foo;
+$var = (clone $a)->foo();
+
+$var = (clone foo())->bar()->foo();
+$var = (clone foo())->bar()->foo();
+$var = (clone foo())->bar()->foo();
+$var = (clone foo())->bar()->foo()[0];
+$var = (clone foo())->bar()->foo()[0][1];
+$var = (clone foo())->bar()->foo()->baz();
+$var = (clone $foo())->bar;
+$var = (clone $bar->y)->x;
+$var = (clone $foo)[0];
+$var = (clone $foo)[0]["string"];
+
+$var = clone $a->b;
+$var = clone $a->b();
+$var = (clone $a)->b();
+$var = (clone $a)->b();
+
+$var = clone $var;
+$var = clone $var;
+$var = clone $var->foo;
+$var = (clone $var->foo)->foo;
+
+================================================================================
+`;
+
+exports[`clone.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -1640,9 +3236,98 @@ var_dump(...(function () use ($type) {})());
 ================================================================================
 `;
 
+exports[`closure.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+(function () {})();
+
+$var = function () {};
+$var = (function () {});
+$var = (function () {})();
+$var = ((function () {})())();
+$func = static function() {};
+$func = (static function() {});
+
+function foo() {
+    $var = (function () {});
+    $var = (function () {})();
+}
+
+call(function () {}, function () {}, function () {});
+call((function () {}), (function () {}), (function () {}));
+
+var_dump(...(function() use ($type) {})());
+
+=====================================output=====================================
+<?php
+
+(function () {})();
+
+$var = function () {};
+$var = function () {};
+$var = (function () {})();
+$var = (function () {})()();
+$func = static function () {};
+$func = static function () {};
+
+function foo()
+{
+    $var = function () {};
+    $var = (function () {})();
+}
+
+call(function () {}, function () {}, function () {});
+call(function () {}, function () {}, function () {});
+
+var_dump(...(function () use ($type) {})());
+
+================================================================================
+`;
+
 exports[`continue.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+continue;
+continue 1;
+continue (1);
+continue ((1));
+continue (((1)));
+continue 2;
+continue (2);
+continue ((2));
+continue (((2)));
+
+=====================================output=====================================
+<?php
+
+continue;
+continue;
+continue;
+continue;
+continue;
+continue 2;
+continue 2;
+continue 2;
+continue 2;
+
+================================================================================
+`;
+
+exports[`continue.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -1901,6 +3586,234 @@ do {
 ================================================================================
 `;
 
+exports[`control-structures.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+if (($a > $b)) {
+    echo "a is bigger than b";
+} elseif (($a == $b)) {
+    echo "a is equal to b";
+} else {
+    echo "a is smaller than b";
+}
+
+while (($i <= 10)) {
+    echo $i++;
+}
+
+do {
+    echo $i;
+} while (($i > 0));
+
+switch (($i)) {
+    case (0):
+        echo "i equals 0";
+        break;
+    case ((1)):
+        echo "i equals 1";
+        break;
+    case ('test' . ( 1 > 2 ? 'foo' : 'bar')):
+        echo "i equals 2";
+        break;
+}
+
+switch (($i + 1)) {
+    case (0):
+        echo "i equals 0";
+        break;
+    case (1 + 2):
+        echo "i equals 1";
+        break;
+    case (1 + ( 1 > 2 ? 1 : 3)):
+        echo "i equals 2";
+        break;
+}
+
+while (++$i) {
+    switch ($i) {
+        case 5:
+            echo "At 5<br />\\n";
+            break (2);  /* Exit only the switch. */
+        case 10:
+            echo "At 10; quitting<br />\\n";
+            break ((4));  /* Exit the switch and the while. */
+        default:
+            break;
+    }
+}
+
+while ($i++ < 5) {
+    echo "Outer<br />\\n";
+    while (1) {
+        echo "Middle<br />\\n";
+        while (1) {
+            echo "Inner<br />\\n";
+            continue (3);
+        }
+        echo "This never gets output.<br />\\n";
+        continue ((2));
+    }
+    echo "Neither does this.<br />\\n";
+}
+
+if ($var = 1) {}
+if (($var = 1)) {}
+if ($var = 1) {} else if ($var = 1) {} else {}
+if (($var = 1)) {} else if (($var = 1)) {} else {}
+do {} while ($var = 1);
+do {} while (($var = 1));
+while ($var = 1) {}
+while (($var = 1)) {}
+for ($i = 1; $i <= 10; $i++) {}
+for (($i = 1); ($i <= 10); ($i++)) {}
+foreach (($arr = [1, 2, 3]) as $value) {}
+foreach (($arr) as $value) {}
+foreach (($arr) as $key => $value) {}
+foreach (($arr = [1, 2, 3]) as $key => $value) {}
+switch ($var = 1) {}
+switch (($var = 1)) {}
+
+while (list($id, $name, $salary) = $result->fetch(PDO::FETCH_NUM)) {}
+while ([$id, $name, $salary] = $result->fetch(PDO::FETCH_NUM)) {}
+
+if (($foo = $bar) && count($foo) > 0) {}
+if( false !== ($file = readdir($dh)) && 0 !== strpos($file,'.')){}
+while (($a = foo()) !== 5) {}
+while( false !== ($file = readdir($dh))){}
+do {} while( false !== ($file = readdir($dh)));
+
+=====================================output=====================================
+<?php
+
+if ($a > $b) {
+    echo "a is bigger than b";
+} elseif ($a == $b) {
+    echo "a is equal to b";
+} else {
+    echo "a is smaller than b";
+}
+
+while ($i <= 10) {
+    echo $i++;
+}
+
+do {
+    echo $i;
+} while ($i > 0);
+
+switch ($i) {
+    case 0:
+        echo "i equals 0";
+        break;
+    case 1:
+        echo "i equals 1";
+        break;
+    case "test" . (1 > 2 ? "foo" : "bar"):
+        echo "i equals 2";
+        break;
+}
+
+switch ($i + 1) {
+    case 0:
+        echo "i equals 0";
+        break;
+    case 1 + 2:
+        echo "i equals 1";
+        break;
+    case 1 + (1 > 2 ? 1 : 3):
+        echo "i equals 2";
+        break;
+}
+
+while (++$i) {
+    switch ($i) {
+        case 5:
+            echo "At 5<br />\\n";
+            break 2; /* Exit only the switch. */
+        case 10:
+            echo "At 10; quitting<br />\\n";
+            break 4; /* Exit the switch and the while. */
+        default:
+            break;
+    }
+}
+
+while ($i++ < 5) {
+    echo "Outer<br />\\n";
+    while (1) {
+        echo "Middle<br />\\n";
+        while (1) {
+            echo "Inner<br />\\n";
+            continue 3;
+        }
+        echo "This never gets output.<br />\\n";
+        continue 2;
+    }
+    echo "Neither does this.<br />\\n";
+}
+
+if ($var = 1) {
+}
+if ($var = 1) {
+}
+if ($var = 1) {
+} elseif ($var = 1) {
+} else {
+}
+if ($var = 1) {
+} elseif ($var = 1) {
+} else {
+}
+do {
+} while ($var = 1);
+do {
+} while ($var = 1);
+while ($var = 1) {
+}
+while ($var = 1) {
+}
+for ($i = 1; $i <= 10; $i++) {
+}
+for ($i = 1; $i <= 10; $i++) {
+}
+foreach ($arr = [1, 2, 3] as $value) {
+}
+foreach ($arr as $value) {
+}
+foreach ($arr as $key => $value) {
+}
+foreach ($arr = [1, 2, 3] as $key => $value) {
+}
+switch ($var = 1) {
+}
+switch ($var = 1) {
+}
+
+while ([$id, $name, $salary] = $result->fetch(PDO::FETCH_NUM)) {
+}
+while ([$id, $name, $salary] = $result->fetch(PDO::FETCH_NUM)) {
+}
+
+if (($foo = $bar) && count($foo) > 0) {
+}
+if (false !== ($file = readdir($dh)) && 0 !== strpos($file, ".")) {
+}
+while (($a = foo()) !== 5) {
+}
+while (false !== ($file = readdir($dh))) {
+}
+do {
+} while (false !== ($file = readdir($dh)));
+
+================================================================================
+`;
+
 exports[`declare.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]
@@ -1923,9 +3836,124 @@ $a->c();
 ================================================================================
 `;
 
+exports[`declare.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+declare(strict_types=1);
+
+($a->c());
+
+=====================================output=====================================
+<?php
+
+declare(strict_types=1);
+
+$a->c();
+
+================================================================================
+`;
+
 exports[`echo.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+echo "Hello World";
+echo ("Hello World");
+
+echo "Sum: ", 1 + 2;
+echo "Hello ", isset($name) ? $name : "John Doe", "!";
+echo "Hello ", (isset($name) ? $name : "John Doe"), "!";
+
+echo 'Sum: ' . (1 + 2);
+echo 'Hello ' . isset($name) ? $name : 'John Doe' . '!';
+echo 'Hello ' . (isset($name) ? $name : 'John Doe') . '!';
+
+echo $some_var ? 'true': 'false';
+echo ($some_var ? 'true': 'false');
+
+echo 'This ', 'string ', 'was ', 'made ', 'with multiple parameters.', chr(10);
+echo ('This '), ('string '), ('was '), ('made '), ('with multiple parameters.'), (chr(10));
+echo 'This ' . 'string ' . 'was ' . 'made ' . 'with concatenation.' . "\\n";
+echo ('This ') . ('string ') . ('was ') . ('made ') . ('with concatenation.') . ("\\n");
+
+echo <<<END
+This uses the "here document" syntax to output
+multiple lines with $variable interpolation. Note
+that the here document terminator must appear on a
+line with just a semicolon. no extra whitespace!
+END;
+
+echo (<<<END
+This uses the "here document" syntax to output
+multiple lines with $variable interpolation. Note
+that the here document terminator must appear on a
+line with just a semicolon. no extra whitespace!
+END
+);
+
+echo (function () { return 'test'; })();
+echo ((function () { return 'test'; })());
+
+=====================================output=====================================
+<?php
+
+echo "Hello World";
+echo "Hello World";
+
+echo "Sum: ", 1 + 2;
+echo "Hello ", isset($name) ? $name : "John Doe", "!";
+echo "Hello ", isset($name) ? $name : "John Doe", "!";
+
+echo "Sum: " . (1 + 2);
+echo "Hello " . isset($name) ? $name : "John Doe" . "!";
+echo "Hello " . (isset($name) ? $name : "John Doe") . "!";
+
+echo $some_var ? "true" : "false";
+echo $some_var ? "true" : "false";
+
+echo "This ", "string ", "was ", "made ", "with multiple parameters.", chr(10);
+echo "This ", "string ", "was ", "made ", "with multiple parameters.", chr(10);
+echo "This " . "string " . "was " . "made " . "with concatenation." . "\\n";
+echo "This " . "string " . "was " . "made " . "with concatenation." . "\\n";
+
+echo <<<END
+This uses the "here document" syntax to output
+multiple lines with $variable interpolation. Note
+that the here document terminator must appear on a
+line with just a semicolon. no extra whitespace!
+END;
+
+echo <<<END
+This uses the "here document" syntax to output
+multiple lines with $variable interpolation. Note
+that the here document terminator must appear on a
+line with just a semicolon. no extra whitespace!
+END;
+
+echo (function () {
+    return "test";
+})();
+echo (function () {
+    return "test";
+})();
+
+================================================================================
+`;
+
+exports[`echo.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -2045,6 +4073,38 @@ if (empty($var)) {
 ================================================================================
 `;
 
+exports[`empty.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+empty($var);
+(empty($var));
+
+$var = empty($var);
+$var = (empty($var));
+
+if ((empty($var))) {}
+
+=====================================output=====================================
+<?php
+
+empty($var);
+empty($var);
+
+$var = empty($var);
+$var = empty($var);
+
+if (empty($var)) {
+}
+
+================================================================================
+`;
+
 exports[`eval.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]
@@ -2088,9 +4148,94 @@ if (eval("return 1;") === 1) {
 ================================================================================
 `;
 
+exports[`eval.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+eval('return 1;');
+(eval('return 1;'));
+(eval(('return 1;')));
+
+$var = eval('return 1;');
+$var = (eval('return 1;'));
+$var = (eval(('return 1;')));
+
+if (eval('return 1;')) {}
+if ((eval('return 1;'))) {}
+
+if ((eval('return 1;')) === 1) {}
+
+=====================================output=====================================
+<?php
+
+eval("return 1;");
+eval("return 1;");
+eval("return 1;");
+
+$var = eval("return 1;");
+$var = eval("return 1;");
+$var = eval("return 1;");
+
+if (eval("return 1;")) {
+}
+if (eval("return 1;")) {
+}
+
+if (eval("return 1;") === 1) {
+}
+
+================================================================================
+`;
+
 exports[`exit.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+exit(1);
+(exit(1));
+
+exit((1));
+
+if (true) exit(1);
+if (true) (exit(1));
+
+call(exit(1));
+call((exit(1)));
+
+=====================================output=====================================
+<?php
+
+exit(1);
+exit(1);
+
+exit(1);
+
+if (true) {
+    exit(1);
+}
+if (true) {
+    exit(1);
+}
+
+call(exit(1));
+call(exit(1));
+
+================================================================================
+`;
+
+exports[`exit.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -2211,9 +4356,129 @@ include $_GET["id"] . ".php";
 ================================================================================
 `;
 
+exports[`include.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+include 'foo.php';
+(include 'foo.php');
+
+include $var;
+(include $var);
+(include ($var));
+
+$var = include 'foo.php';
+$var = (include 'foo.php');
+$var = include $var;
+$var = (include $var);
+$var = (include ($var));
+
+function foo() {
+    include 'foo.php';
+    (include 'foo.php');
+}
+
+if (include('vars.php') == TRUE) {}
+if ((include 'vars.php') == TRUE) {}
+
+include $path . 'example-config-file.php';
+include ($path) . ('example-config-file.php');
+include (($path) . ('example-config-file.php'));
+
+include __DIR__ . '/../src/includeFile.php';
+include (__DIR__) . ('/../src/includeFile.php');
+include ((__DIR__) . ('/../src/includeFile.php'));
+
+include(dirname(dirname(__FILE__)) . '/prepend.php');
+
+include ($_GET['id'].".php");
+
+=====================================output=====================================
+<?php
+
+include "foo.php";
+include "foo.php";
+
+include $var;
+include $var;
+include $var;
+
+$var = include "foo.php";
+$var = include "foo.php";
+$var = include $var;
+$var = include $var;
+$var = include $var;
+
+function foo()
+{
+    include "foo.php";
+    include "foo.php";
+}
+
+if (include "vars.php" == true) {
+}
+if ((include "vars.php") == true) {
+}
+
+include $path . "example-config-file.php";
+include $path . "example-config-file.php";
+include $path . "example-config-file.php";
+
+include __DIR__ . "/../src/includeFile.php";
+include __DIR__ . "/../src/includeFile.php";
+include __DIR__ . "/../src/includeFile.php";
+
+include dirname(dirname(__FILE__)) . "/prepend.php";
+
+include $_GET["id"] . ".php";
+
+================================================================================
+`;
+
 exports[`isset.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+isset($var);
+(isset($var));
+
+$var = isset($var);
+$var = (isset($var));
+$var = isset($var, $var, $var);
+$var = (isset($var, $var, $var));
+
+if ((isset($var))) {}
+
+=====================================output=====================================
+<?php
+
+isset($var);
+isset($var);
+
+$var = isset($var);
+$var = isset($var);
+$var = isset($var, $var, $var);
+$var = isset($var, $var, $var);
+
+if (isset($var)) {
+}
+
+================================================================================
+`;
+
+exports[`isset.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -2438,9 +4703,225 @@ $var = (function () {
 ================================================================================
 `;
 
+exports[`lookups.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+$var->bar;
+($var->bar);
+
+$var->bar();
+($var->bar());
+
+$var::bar();
+($var::bar());
+
+$var = $var->bar;
+$var = ($var->bar);
+$var = $var->bar->foo;
+$var = ($var->bar)->foo;
+$var = ($var->bar->foo);
+$var = (($var->bar)->foo);
+
+$var = $var::foo();
+$var = ($var::foo());
+$var = $var::foo()::bar();
+$var = ($var::foo())::bar();
+$var = ($var::foo()::bar());
+$var = (($var::foo())::bar());
+
+$var = $var->bar();
+$var = ($var->bar());
+$var = $var->bar()->foo();
+$var = ($var->bar())->foo();
+$var = ($var->bar()->foo());
+$var = (($var->bar())->foo());
+
+$var = ((object) ($var->bar())->foo());
+$var = (object) (($var->bar())->foo());
+
+$var = $var[0];
+$var = $var[0][1];
+$var = ($var[0]);
+$var = ($var[0][1]);
+$var = $var[0]->foo;
+$var = ($var[0])->foo;
+$var = ($var[0][1])->foo;
+$var = ($var[0])[1]->foo;
+$var = (($var[0])[1])->foo;
+$var = $var[0]::foo;
+$var = ($var[0])::foo;
+$var = ($var[0][1])::foo;
+$var = ($var[0])[1]::foo;
+$var = (($var[0])[1])::foo;
+$var = $var[0]->foo();
+$var = ($var[0])->foo();
+$var = ($var[0][1])->foo();
+$var = ($var[0])[1]->foo();
+$var = (($var[0])[1])->foo();
+$var = $var[0]::foo();
+$var = ($var[0])::foo();
+$var = ($var[0][1])::foo();
+$var = ($var[0])[1]::foo();
+$var = (($var[0])[1])::foo();
+
+$var = $var[0]->foo()->baz;
+$var = ((($var[0])->foo())->baz);
+
+$var = (new Foo())->bar;
+$var = (new Foo())::bar;
+$var = (new Foo())->bar();
+$var = (new Foo())::bar();
+$var = (new Foo())[1];
+
+$var = $var->bar()();
+$var = ($var->bar())();
+$var = ($var->bar()());
+$var = (($var->bar())());
+
+$var = $var::bar()();
+$var = ($var::bar())();
+$var = ($var::bar()());
+$var = (($var::bar())());
+
+$var = ($var)->bar;
+$var = (($var)->bar);
+$var = ($var)->bar();
+$var = (($var)->bar());
+
+$var = (function () {
+    return $this->foo;
+})->bindTo($var, A::class)();
+$var = (((function () {
+    return $this->foo;
+})))->bindTo($var, A::class)();
+
+=====================================output=====================================
+<?php
+
+$var->bar;
+$var->bar;
+
+$var->bar();
+$var->bar();
+
+$var::bar();
+$var::bar();
+
+$var = $var->bar;
+$var = $var->bar;
+$var = $var->bar->foo;
+$var = $var->bar->foo;
+$var = $var->bar->foo;
+$var = $var->bar->foo;
+
+$var = $var::foo();
+$var = $var::foo();
+$var = $var::foo()::bar();
+$var = $var::foo()::bar();
+$var = $var::foo()::bar();
+$var = $var::foo()::bar();
+
+$var = $var->bar();
+$var = $var->bar();
+$var = $var->bar()->foo();
+$var = $var->bar()->foo();
+$var = $var->bar()->foo();
+$var = $var->bar()->foo();
+
+$var = ((object) $var->bar()->foo());
+$var = (object) $var->bar()->foo();
+
+$var = $var[0];
+$var = $var[0][1];
+$var = $var[0];
+$var = $var[0][1];
+$var = $var[0]->foo;
+$var = $var[0]->foo;
+$var = $var[0][1]->foo;
+$var = $var[0][1]->foo;
+$var = $var[0][1]->foo;
+$var = $var[0]::foo;
+$var = $var[0]::foo;
+$var = $var[0][1]::foo;
+$var = $var[0][1]::foo;
+$var = $var[0][1]::foo;
+$var = $var[0]->foo();
+$var = $var[0]->foo();
+$var = $var[0][1]->foo();
+$var = $var[0][1]->foo();
+$var = $var[0][1]->foo();
+$var = $var[0]::foo();
+$var = $var[0]::foo();
+$var = $var[0][1]::foo();
+$var = $var[0][1]::foo();
+$var = $var[0][1]::foo();
+
+$var = $var[0]->foo()->baz;
+$var = $var[0]->foo()->baz;
+
+$var = (new Foo())->bar;
+$var = (new Foo())::bar;
+$var = (new Foo())->bar();
+$var = (new Foo())::bar();
+$var = (new Foo())[1];
+
+$var = $var->bar()();
+$var = $var->bar()();
+$var = $var->bar()();
+$var = $var->bar()();
+
+$var = $var::bar()();
+$var = $var::bar()();
+$var = $var::bar()();
+$var = $var::bar()();
+
+$var = $var->bar;
+$var = $var->bar;
+$var = $var->bar();
+$var = $var->bar();
+
+$var = (function () {
+    return $this->foo;
+})->bindTo($var, A::class)();
+$var = (function () {
+    return $this->foo;
+})->bindTo($var, A::class)();
+
+================================================================================
+`;
+
 exports[`namespace.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+namespace Foo;
+
+($a->c());
+
+=====================================output=====================================
+<?php
+
+namespace Foo;
+
+$a->c();
+
+================================================================================
+`;
+
+exports[`namespace.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -2578,6 +5059,125 @@ $var = (new class {})->foo;
 ================================================================================
 `;
 
+exports[`new.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+(new Translator(
+    $container,
+    new MessageFormatter(),
+    'en',
+    array(),
+    array('foo' => 'bar')
+))
+?>
+<?php
+(((new Translator(
+    $container,
+    new MessageFormatter(),
+    'en',
+    $someOtherVar,
+    array('foo' => 'bar')
+))))
+?>
+<?php
+(new Translator(
+    $container,
+    new MessageFormatter(),
+    'en',
+    $someOtherVar,
+    ['foo' => 'bar']
+))
+?>
+<?php
+
+$var = new Foo();
+$var = (new Foo());
+$var = (new Foo())->c();
+$var = (new class {
+    public function log($msg)
+    {
+        echo $msg;
+    }
+});
+$var = (new foo())->bar();
+$var = (new foo())->bar()->foo();
+$var = ((new foo())->bar())->foo();
+$var = (((new foo())->bar())->foo());
+$var = (((new foo())->bar())->foo())[0];
+$var = ((((new foo())->bar())->foo())[0])[1];
+$var = (((new foo())->bar())->foo())->baz();
+$var = (new $foo())->bar;
+$var = (new $bar->y)->x;
+$var = (new foo)[0];
+$var = (new foo)[0]['string'];
+
+$var = new $a->b;
+$var = new $a->b();
+$var = (new $a)->b();
+$var = ((new $a)->b());
+
+(new class {})->foo;
+(new class {})->foo();
+(new class {})();
+(new class {})['foo'];
+
+$var = (new class {})->foo;
+
+=====================================output=====================================
+<?php
+new Translator(
+    $container,
+    new MessageFormatter(),
+    "en",
+    [],
+    ["foo" => "bar"],
+); ?>
+<?php new Translator($container, new MessageFormatter(), "en", $someOtherVar, [
+    "foo" => "bar",
+]); ?>
+<?php new Translator($container, new MessageFormatter(), "en", $someOtherVar, [
+    "foo" => "bar",
+]); ?>
+<?php
+$var = new Foo();
+$var = new Foo();
+$var = (new Foo())->c();
+$var = new class {
+    public function log($msg)
+    {
+        echo $msg;
+    }
+};
+$var = (new foo())->bar();
+$var = (new foo())->bar()->foo();
+$var = (new foo())->bar()->foo();
+$var = (new foo())->bar()->foo();
+$var = (new foo())->bar()->foo()[0];
+$var = (new foo())->bar()->foo()[0][1];
+$var = (new foo())->bar()->foo()->baz();
+$var = (new $foo())->bar;
+$var = (new $bar->y())->x;
+$var = (new foo())[0];
+$var = (new foo())[0]["string"];
+$var = new $a->b();
+$var = new $a->b();
+$var = (new $a())->b();
+$var = (new $a())->b();
+(new class {})->foo;
+(new class {})->foo();
+(new class {})();
+(new class {})["foo"];
+$var = (new class {})->foo;
+
+
+================================================================================
+`;
+
 exports[`parens.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]
@@ -2596,9 +5196,157 @@ include $test ? "foo" : "bar";
 ================================================================================
 `;
 
+exports[`parens.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+include 'foo.php' . ($test ? 'foo' : 'bar');
+include ($test ? 'foo' : 'bar');
+
+=====================================output=====================================
+<?php
+include "foo.php" . ($test ? "foo" : "bar");
+include $test ? "foo" : "bar";
+
+================================================================================
+`;
+
 exports[`pre-post.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+++$var;
+(++$var);
+
+$var++;
+($var++);
+
+--$var;
+(--$var);
+
+$var--;
+($var--);
+
+$var = ++$var;
+$var = (++$var);
+
+$var = +(++$var);
+$var = -(++$var);
+$var = ~(++$var);
+
+$var = +(--$var);
+$var = -(--$var);
+$var = ~(--$var);
+
+$var = +($var++);
+$var = -($var++);
+$var = ~($var++);
+
+$var = +($var--);
+$var = -($var--);
+$var = ~($var--);
+
+$var = ++$var ** 2;
+$var = (++$var) ** 2;
+
+$var = $var++ ** 2;
+$var = ($var++) ** 2;
+
+$var = +(+(++$var));
+$var = +(+($var++));
+$var = ~(-(++$var));
+$var = ~(-($var++));
+
+$a->b++;
+($a->b++);
+++$a->b;
+(++$a)->b;
+
+($a->b++)->call();
+($a->b++)[1];
+($var++)();
+$var = call($var->_uuidCounter++);
+
+(--$a->b)->call();
+(--$a->b)[1];
+(--$var)();
+$var = call(--$var->_uuidCounter);
+
+=====================================output=====================================
+<?php
+
+++$var;
+++$var;
+
+$var++;
+$var++;
+
+--$var;
+--$var;
+
+$var--;
+$var--;
+
+$var = ++$var;
+$var = ++$var;
+
+$var = +(++$var);
+$var = -++$var;
+$var = ~++$var;
+
+$var = +--$var;
+$var = -(--$var);
+$var = ~--$var;
+
+$var = +$var++;
+$var = -$var++;
+$var = ~$var++;
+
+$var = +$var--;
+$var = -$var--;
+$var = ~$var--;
+
+$var = (++$var) ** 2;
+$var = (++$var) ** 2;
+
+$var = ($var++) ** 2;
+$var = ($var++) ** 2;
+
+$var = +(+(++$var));
+$var = +(+$var++);
+$var = ~-++$var;
+$var = ~-$var++;
+
+$a->b++;
+$a->b++;
+++$a->b;
+(++$a)->b;
+
+($a->b++)->call();
+($a->b++)[1];
+($var++)();
+$var = call($var->_uuidCounter++);
+
+(--$a->b)->call();
+(--$a->b)[1];
+(--$var)();
+$var = call(--$var->_uuidCounter);
+
+================================================================================
+`;
+
+exports[`pre-post.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -2823,6 +5571,106 @@ print ($var || $var) && $var;
 ================================================================================
 `;
 
+exports[`print.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+print("Hello World");
+(print("Hello World"));
+
+print "print() also works without parentheses.";
+
+print "This spans
+multiple lines. The newlines will be
+output as well";
+(print "This spans
+multiple lines. The newlines will be
+output as well");
+
+print <<<END
+This uses the "here document" syntax to output
+multiple lines with $variable interpolation. Note
+that the here document terminator must appear on a
+line with just a semicolon no extra whitespace!
+END;
+
+print (<<<END
+This uses the "here document" syntax to output
+multiple lines with $variable interpolation. Note
+that the here document terminator must appear on a
+line with just a semicolon no extra whitespace!
+END
+);
+
+if (print("foo") && print("bar")) {
+}
+
+if ((print("foo")) && (print("bar"))) {
+}
+
+$var = $var ? print "$string_message<br />" : print "$string_message\\n";
+$var = $var ? (print "$string_message<br />") : (print "$string_message\\n");
+$var = $var ? (print ("$string_message<br />")) : (print ("$string_message\\n"));
+
+print 1 . print(2) + 3; // 511
+print 1 . (print(2)) + 3; // 214
+
+print ($var || $var) && $var;
+print (($var || $var) && $var);
+
+=====================================output=====================================
+<?php
+
+print "Hello World";
+print "Hello World";
+
+print "print() also works without parentheses.";
+
+print "This spans
+multiple lines. The newlines will be
+output as well";
+print "This spans
+multiple lines. The newlines will be
+output as well";
+
+print <<<END
+This uses the "here document" syntax to output
+multiple lines with $variable interpolation. Note
+that the here document terminator must appear on a
+line with just a semicolon no extra whitespace!
+END;
+
+print <<<END
+This uses the "here document" syntax to output
+multiple lines with $variable interpolation. Note
+that the here document terminator must appear on a
+line with just a semicolon no extra whitespace!
+END;
+
+if (print "foo" && (print "bar")) {
+}
+
+if ((print "foo") && (print "bar")) {
+}
+
+$var = $var ? print "$string_message<br />" : print "$string_message\\n";
+$var = $var ? print "$string_message<br />" : print "$string_message\\n";
+$var = $var ? print "$string_message<br />" : print "$string_message\\n";
+
+print 1 . (print 2 + 3); // 511
+print 1 . (print 2) + 3; // 214
+
+print ($var || $var) && $var;
+print ($var || $var) && $var;
+
+================================================================================
+`;
+
 exports[`program.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]
@@ -2841,9 +5689,174 @@ $a->c();
 ================================================================================
 `;
 
+exports[`program.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+($a->c());
+
+=====================================output=====================================
+<?php
+
+$a->c();
+
+================================================================================
+`;
+
 exports[`retif.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+$var ? 1 : 2;
+($var ? 1 : 2);
+
+$var = $var ? 1 : 2;
+$var = ($var ? 1 : 2);
+
+$var = (int) ($var + 1 === 2 ? '1' : '2');
+$var = (int) $var + 1 === 2 ? '1' : '2';
+$var = ((int) $var) + 1 === 2 ? '1' : '2';
+
+($var ? $var : $var)();
+($var ? $var : $var)->prop;
+($var ? $var : $var)->prop();
+($var ? $var : $var)[1];
+($var ? $var : $var)->d();
+($var ? $var : $var)->d()->e();
+($var ? $var : $var)->d()->e()->f();
+($var
+    ? $var->responseBody($var->currentUser)
+    : $var->responseBody($var->defaultUser))
+->map();
+($var
+    ? $var.responseBody($var->currentUser)
+    : $var.responseBody($var->defaultUser))
+->map()->filter();
+($var
+    ? $var.responseBody($var->currentUser)
+    : $var.responseBody($var))
+->map();
+$var[$var
+    ? $var->responseBody($var->currentUser)
+    : $var->responseBody($var)]
+->map();
+
+$var = $var . $var ? "()" : "";
+$var = ($var . $var) ? "()" : "";
+$var = $var . ($var ? "()" : "");
+$var = +($var ? 1 : 2);
+$var = +(+$var ? 1 : 2);
+$var = +($var++ ? 1 : 2);
+$var = ((true ? 'true' : false) ? (true ? 'true' : false) : (true ? 'true' : false));
+$var = $var ? $var1 ? 1 : 2 : $var2 ? 3 : 4;
+
+$var = $var ?: $var ?: $var ?: 'string';
+$var = ($var ?: $var) ?: $var ?: 'string';
+$var = (($var ?: $var) ?: $var) ?: 'string';
+$var = ((($var ?: $var) ?: $var) ?: 'string');
+$var = ($var ?: ($var ?: $var)) ?: 'string';
+$var = ($var ?: (($var ?: $var) ?: 'string'));
+$var = ($var ?: ($var ?: ($var ?: 'string')));
+
+$var = ($foo and $bar) ? true : false;
+$var = ($foo or $bar) ? true : false;
+$var = ($foo xor $bar) ? true : false;
+$var = ($foo = "bar") ? true : false;
+
+$var = ($foo && $bar) ? true : false;
+$var = ($foo || $bar) ? true : false;
+$var = (!$foo) ? true : false;
+$var = (new $foo) ? true : false;
+
+=====================================output=====================================
+<?php
+
+$var ? 1 : 2;
+$var ? 1 : 2;
+
+$var = $var ? 1 : 2;
+$var = $var ? 1 : 2;
+
+$var = (int) ($var + 1 === 2 ? "1" : "2");
+$var = (int) $var + 1 === 2 ? "1" : "2";
+$var = ((int) $var) + 1 === 2 ? "1" : "2";
+
+($var ? $var : $var)();
+($var ? $var : $var)->prop;
+($var ? $var : $var)->prop();
+($var ? $var : $var)[1];
+($var ? $var : $var)->d();
+($var ? $var : $var)->d()->e();
+($var ? $var : $var)->d()->e()->f();
+($var
+    ? $var->responseBody($var->currentUser)
+    : $var->responseBody($var->defaultUser)
+)->map();
+($var
+    ? $var . responseBody($var->currentUser)
+    : $var . responseBody($var->defaultUser)
+)
+    ->map()
+    ->filter();
+($var
+    ? $var . responseBody($var->currentUser)
+    : $var . responseBody($var)
+)->map();
+$var[
+    $var ? $var->responseBody($var->currentUser) : $var->responseBody($var)
+]->map();
+
+$var = $var . $var ? "()" : "";
+$var = $var . $var ? "()" : "";
+$var = $var . ($var ? "()" : "");
+$var = +($var ? 1 : 2);
+$var = +(+$var ? 1 : 2);
+$var = +($var++ ? 1 : 2);
+$var = (true
+        ? "true"
+        : false)
+    ? (true
+        ? "true"
+        : false)
+    : (true
+        ? "true"
+        : false);
+$var = ($var ? ($var1 ? 1 : 2) : $var2) ? 3 : 4;
+
+$var = $var ?: $var ?: $var ?: "string";
+$var = $var ?: $var ?: $var ?: "string";
+$var = $var ?: $var ?: $var ?: "string";
+$var = $var ?: $var ?: $var ?: "string";
+$var = $var ?: ($var ?: $var) ?: "string";
+$var = $var ?: ($var ?: $var ?: "string");
+$var = $var ?: ($var ?: ($var ?: "string"));
+
+$var = ($foo and $bar) ? true : false;
+$var = ($foo or $bar) ? true : false;
+$var = ($foo xor $bar) ? true : false;
+$var = ($foo = "bar") ? true : false;
+
+$var = $foo && $bar ? true : false;
+$var = $foo || $bar ? true : false;
+$var = !$foo ? true : false;
+$var = new $foo() ? true : false;
+
+================================================================================
+`;
+
+exports[`retif.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -3026,6 +6039,47 @@ return $this->customer->paymentService ?? null;
 ================================================================================
 `;
 
+exports[`return.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+return;
+return 1;
+return (1);
+return (1 + 2);
+return ('veryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString' . 'veryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString');
+return ($var1 + $var2);
+return $var ? ($var1 ? 1 : 2) : ($var2 ? 3 : 4);
+return ('veryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString' ? 'veryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString' : 'veryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString');
+return static::class . '@' . $method;
+return ($this->customer->paymentService ?? null);
+
+
+=====================================output=====================================
+<?php
+
+return;
+return 1;
+return 1;
+return 1 + 2;
+return "veryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString" .
+    "veryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString";
+return $var1 + $var2;
+return $var ? ($var1 ? 1 : 2) : ($var2 ? 3 : 4);
+return "veryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString"
+    ? "veryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString"
+    : "veryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString";
+return static::class . "@" . $method;
+return $this->customer->paymentService ?? null;
+
+================================================================================
+`;
+
 exports[`silent.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]
@@ -3139,6 +6193,120 @@ echo @(1 / 0);
 ================================================================================
 `;
 
+exports[`silent.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+@foo();
+(@foo());
+
+$var = @foo();
+$var = (@foo());
+
+$var = @call() || @other();
+$var = @(call()) || @(other_class());
+$var = @(call() || call());
+
+$var = @$cache[$key];
+$var = @($cache[$key]);
+
+$var = @new MyClass();
+$var = @(new MyClass());
+
+$var = (@include("file.php")) OR die("Could not find file.php!");
+
+$var = @  $_GET['data'];
+
+if (false === @fwrite($this->stream, $message) || ($newline && (false === @fwrite($this->stream, PHP_EOL)))) {
+    // should never happen
+    throw new RuntimeException('Unable to write output.');
+}
+
+try {
+    if (($fp = @fopen($filename, "r")) == false) {
+        throw new Exception;
+    } else {
+        do_file_stuff();
+    }
+} catch (Exception $e) {
+    handle_exception();
+}
+
+@list($width, $height) = getimagesize($file);
+// Todo https://github.com/glayzzle/php-parser/issues/356
+// @(list($width, $height) = getimagesize($file));
+
+@$var += 10;
+// Todo https://github.com/glayzzle/php-parser/issues/356
+// @($var += 10);
+
+echo @(1 / 0);
+
+@$i / 0;
+@($i / 0);
+
+=====================================output=====================================
+<?php
+
+@foo();
+@foo();
+
+$var = @foo();
+$var = @foo();
+
+$var = @call() || @other();
+$var = @call() || @other_class();
+$var = @(call() || call());
+
+$var = @$cache[$key];
+$var = @$cache[$key];
+
+$var = @new MyClass();
+$var = @new MyClass();
+
+($var = @include "file.php") or die("Could not find file.php!");
+
+$var = @$_GET["data"];
+
+if (
+    false === @fwrite($this->stream, $message) ||
+    ($newline && false === @fwrite($this->stream, PHP_EOL))
+) {
+    // should never happen
+    throw new RuntimeException("Unable to write output.");
+}
+
+try {
+    if (($fp = @fopen($filename, "r")) == false) {
+        throw new Exception();
+    } else {
+        do_file_stuff();
+    }
+} catch (Exception $e) {
+    handle_exception();
+}
+
+@[$width, $height] = getimagesize($file);
+// Todo https://github.com/glayzzle/php-parser/issues/356
+// @(list($width, $height) = getimagesize($file));
+
+@$var += 10;
+// Todo https://github.com/glayzzle/php-parser/issues/356
+// @($var += 10);
+
+echo @(1 / 0);
+
+@$i / 0;
+@($i / 0);
+
+================================================================================
+`;
+
 exports[`throw.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]
@@ -3192,9 +6360,208 @@ $value = $a ? $a : throw new \\InvalidArgumentException("In ternary");
 ================================================================================
 `;
 
+exports[`throw.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+throw new Exception('Division by zero.');
+throw (new Exception('Division by zero.'));
+throw $e;
+throw ($e);
+throw new \\Exception("Bye");
+throw (new \\Exception("Bye"));
+
+if (!$var) {
+    throw new Exception('Division by zero.');
+    throw (new Exception('Division by zero.'));
+    throw $e;
+    throw ($e);
+    throw new \\Exception("Bye");
+    throw (new \\Exception("Bye"));
+}
+
+die(throw new \\Exception('In Statement'));
+$throws = fn() => throw new \\RuntimeException('In arrow function');
+$value = $a ? $a : throw new \\InvalidArgumentException('In ternary');
+=====================================output=====================================
+<?php
+
+throw new Exception("Division by zero.");
+throw new Exception("Division by zero.");
+throw $e;
+throw $e;
+throw new \\Exception("Bye");
+throw new \\Exception("Bye");
+
+if (!$var) {
+    throw new Exception("Division by zero.");
+    throw new Exception("Division by zero.");
+    throw $e;
+    throw $e;
+    throw new \\Exception("Bye");
+    throw new \\Exception("Bye");
+}
+
+die(throw new \\Exception("In Statement"));
+$throws = fn() => throw new \\RuntimeException("In arrow function");
+$value = $a ? $a : throw new \\InvalidArgumentException("In ternary");
+
+================================================================================
+`;
+
 exports[`unary.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
++$var;
++($var);
+(+$var);
+
+-$var;
+-($var);
+(-$var);
+
+~$var;
+~($var);
+(~$var);
+
+!$var;
+!($var);
+(!$var);
+
+!!$var;
+!(!$var);
+(!(!$var));
+(!!$var);
+
+$var = (+$var);
+$var = +(+$var);
+
+$var = (-$var);
+$var = -(-$var);
+
+$var = -(+$var);
+$var = +(-$var);
+
+$var = (~$var);
+$var = ~(~$var);
+
+$var = (!$var);
+$var = !(!$var);
+
+$a = +$a ** 1;
+$a = (+$a) ** 1;
+$a = 1 ** (+$a);
+
+$var = call(+$a);
+$var = call((+$a));
+
+$var = +($foo->bar);
+
+$var = +$var || +$var;
+$var = (+$var) || (+$var);
+$var = ((+$var) || (+$var));
+
+$var = -(+($var));
+
+$var = ~(+$var);
+
+$var = ~$var += 1;
+$var = ~($var += 1);
+
+(+$a->b)->call();
+(+$a->b)[1];
+(+$var)();
+$var = call(+$var->_uuidCounter);
+
+if (!$token = $this->getToken()) {}
+if (!($token = $this->getToken())) {}
+
+=====================================output=====================================
+<?php
+
++$var;
++$var;
++$var;
+
+-$var;
+-$var;
+-$var;
+
+~$var;
+~$var;
+~$var;
+
+!$var;
+!$var;
+!$var;
+
+!!$var;
+!!$var;
+!!$var;
+!!$var;
+
+$var = +$var;
+$var = +(+$var);
+
+$var = -$var;
+$var = -(-$var);
+
+$var = -+$var;
+$var = +-$var;
+
+$var = ~$var;
+$var = ~~$var;
+
+$var = !$var;
+$var = !!$var;
+
+$a = (+$a) ** 1;
+$a = (+$a) ** 1;
+$a = 1 ** +$a;
+
+$var = call(+$a);
+$var = call(+$a);
+
+$var = +$foo->bar;
+
+$var = +$var || +$var;
+$var = +$var || +$var;
+$var = +$var || +$var;
+
+$var = -+$var;
+
+$var = ~+$var;
+
+$var = ~($var += 1);
+$var = ~($var += 1);
+
+(+$a->b)->call();
+(+$a->b)[1];
+(+$var)();
+$var = call(+$var->_uuidCounter);
+
+if (!($token = $this->getToken())) {
+}
+if (!($token = $this->getToken())) {
+}
+
+================================================================================
+`;
+
+exports[`unary.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -3458,9 +6825,230 @@ function foo($a = 1, $b = "string", $c = true, $d = __LINE__)
 ================================================================================
 `;
 
+exports[`unnecessary.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+$test = 1;
+$test = (1);
+$test = ((1));
+$test = (((1)));
+
+$var = (true);
+$var = (false);
+
+$var = ('string');
+$var = ("string");
+$var = ("string");
+
+$var = (1234); // decimal number
+$var = (-123); // a negative number
+$var = -(123); // a negative number
+$var = (0123); // octal number (equivalent to 83 decimal)
+$var = (0x1A); // hexadecimal number (equivalent to 26 decimal)
+$var = (0b11111111); // binary number (equivalent to 255 decimal)
+
+$var = (__LINE__);
+
+$var = (<<<EOD
+Example of string
+spanning multiple lines
+using heredoc syntax.
+EOD
+);
+$var = (
+<<<EOD
+Example of string
+spanning multiple lines
+using heredoc syntax.
+EOD
+);
+
+$var = (<<<'EOD'
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOD
+);
+
+$var = (
+<<<'EOD'
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOD
+);
+
+$var = ($var);
+$var = ($$var);
+
+function foo($a = (1), $b = ('string'), $c = (true), $d = (__LINE__))
+{
+    echo "Example function.\\n";
+}
+
+=====================================output=====================================
+<?php
+$test = 1;
+$test = 1;
+$test = 1;
+$test = 1;
+
+$var = true;
+$var = false;
+
+$var = "string";
+$var = "string";
+$var = "string";
+
+$var = 1234; // decimal number
+$var = -123; // a negative number
+$var = -123; // a negative number
+$var = 0123; // octal number (equivalent to 83 decimal)
+$var = 0x1a; // hexadecimal number (equivalent to 26 decimal)
+$var = 0b11111111; // binary number (equivalent to 255 decimal)
+
+$var = __LINE__;
+
+$var = <<<EOD
+Example of string
+spanning multiple lines
+using heredoc syntax.
+EOD;
+$var = <<<EOD
+Example of string
+spanning multiple lines
+using heredoc syntax.
+EOD;
+
+$var = <<<'EOD'
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOD;
+
+$var = <<<'EOD'
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOD;
+
+$var = $var;
+$var = $$var;
+
+function foo($a = 1, $b = "string", $c = true, $d = __LINE__)
+{
+    echo "Example function.\\n";
+}
+
+================================================================================
+`;
+
 exports[`yield.php 1`] = `
 ====================================options=====================================
 parsers: ["php"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+function gen_one_to_three() {
+    for ($i = 1; $i <= 3; $i++) {
+        yield;
+        yield $i;
+        (yield $i);
+        yield from from();
+        (yield from from());
+        (yield f())->b;
+        !(yield $var);
+        yield (yield $var);
+    }
+
+    $var = yield;
+    $var = yield $var;
+    $var += yield $var;
+    $var = (yield $var);
+    $var += (yield $var);
+    $var = yield $key => $var;
+    $var = (yield $key => $var);
+    $var = !yield $var;
+    $var = !(yield $var);
+    $var = yield (yield $var);
+    $var = yield 1 ? 1 : 1;
+    $var = (yield 1) ? 1 : 1;
+    $var = yield 1 ? yield 1 : yield 1;
+    $var = (yield 1) ? (yield 1) : (yield 1);
+    $var = yield $var->b;
+    $var = (yield $var)->b;
+    $var = yield $var->b();
+    $var = (yield $var)->b();
+    $var = yield $var[1];
+    $var = (yield $var)[1];
+
+    call(yield $var);
+
+    return yield from nine_ten();
+
+    foreach($SubTrav as $SubItem) yield $SubItem;
+}
+
+=====================================output=====================================
+<?php
+
+function gen_one_to_three()
+{
+    for ($i = 1; $i <= 3; $i++) {
+        yield;
+        yield $i;
+        yield $i;
+        yield from from();
+        yield from from();
+        (yield f())->b;
+        !(yield $var);
+        yield (yield $var);
+    }
+
+    $var = yield;
+    $var = (yield $var);
+    $var += (yield $var);
+    $var = (yield $var);
+    $var += (yield $var);
+    $var = (yield $key => $var);
+    $var = (yield $key => $var);
+    $var = !(yield $var);
+    $var = !(yield $var);
+    $var = (yield (yield $var));
+    $var = (yield 1 ? 1 : 1);
+    $var = (yield 1) ? 1 : 1;
+    $var = (yield 1 ? yield 1 : yield 1);
+    $var = (yield 1) ? yield 1 : yield 1;
+    $var = (yield $var->b);
+    $var = (yield $var)->b;
+    $var = (yield $var->b());
+    $var = (yield $var)->b();
+    $var = (yield $var[1]);
+    $var = (yield $var)[1];
+
+    call(yield $var);
+
+    return yield from nine_ten();
+
+    foreach ($SubTrav as $SubItem) {
+        yield $SubItem;
+    }
+}
+
+================================================================================
+`;
+
+exports[`yield.php 2`] = `
+====================================options=====================================
+parsers: ["php"]
+phpVersion: "8.4"
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/parens/jsfmt.spec.mjs
+++ b/tests/parens/jsfmt.spec.mjs
@@ -1,1 +1,2 @@
 run_spec(import.meta, ["php"]);
+run_spec(import.meta, ["php"], { phpVersion: "8.4" });

--- a/tests/parens/new.php
+++ b/tests/parens/new.php
@@ -30,6 +30,9 @@
 $var = new Foo();
 $var = (new Foo());
 $var = (new Foo())->c();
+new Foo->prop;
+new Foo->method();
+new Foo->$var;
 $var = (new class {
     public function log($msg)
     {
@@ -45,8 +48,16 @@ $var = ((((new foo())->bar())->foo())[0])[1];
 $var = (((new foo())->bar())->foo())->baz();
 $var = (new $foo())->bar;
 $var = (new $bar->y)->x;
+new SortOfLongClassName()->withALongMethodName()->andAnother()->toPushItPast80Chars();
+$asdf =
+new SortOfLongClassName()->withALongMethodName()
+    ->andAnother()->toPushItPast80Chars();
+
 $var = (new foo)[0];
 $var = (new foo)[0]['string'];
+
+$var = (new Foo)::foo;
+$var = (new Foo)::$foo;
 
 $var = new $a->b;
 $var = new $a->b();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4701,10 +4701,10 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-php-parser@^3.2.4:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/php-parser/-/php-parser-3.2.4.tgz#56f97438a46c54ce0e78a8357782402f9530f892"
-  integrity sha512-X1HIaSHCb9aAReEqb+U/AAB3evE1iKD6tAY/lw9+wT4koCkWhg22m4LNtFGwd3Qv4PYIL2+zl+oXh00ALKya0Q==
+php-parser@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/php-parser/-/php-parser-3.2.5.tgz#24ff4b4f3e1788967f7737e43c273a5a8e7cd0ac"
+  integrity sha512-M1ZYlALFFnESbSdmRtTQrBFUHSriHgPhgqtTF/LCbZM4h7swR5PHtUceB2Kzby5CfqcsYwBn7OXTJ0+8Sajwkw==
 
 picocolors@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This adds support for formatting things like `(new Foo())->bar` as `new Foo()->bar`. Support for this syntax was [added in PHP 8.4](https://www.php.net/releases/8.4/en.php#new_without_parentheses) and [very recently merged and released](https://github.com/glayzzle/php-parser/pull/1146) in php-parser. 

~~**Note** that php-parser 3.2.2 introduced a parser bug that affects how we format specifically placed comments in class constant assignments. My opinion is that this is an extreme edge case issue and it's worth the temporary regression in order to gain support for one of the highlighted features of php 8.4. (There is already a [pending PR](https://github.com/glayzzle/php-parser/pull/1152) to fix this in php-parser, and we can rollout an update to fix it here when that lands.~~ edit: this has been fixed

- bumps php-parser to the newly released v3.2.3
- ~~**breaking:** removes (temporarily) support for some comments in class constant assigments~~ 
- adds a new `phpVersion` option for `8.4`
- adds support for the above syntax, with tests
- misc light refactoring to support these changes

**Verification**
1. I used this to format all text fixture files and confirmed that now (relevant) issues were introduced.
2. I used this to format a small Laravel project of mine (300+ files, 27k lines of code) and confirmed that the tests still passed.

**Try it out**
```php
<?php

class Foo 
{
    public $bar = 123;
}

echo (new Foo)->bar;
```
This should be reformatted to
```diff
-echo (new Foo)->bar;
+echo new Foo()->bar;
```
And `php foo.php` should print `123` in both cases (though the latter will fail in php <= 8.3).