### PR TITLE
fix: attribute PSR compatibility

### DIFF
--- a/src/printer.mjs
+++ b/src/printer.mjs
@@ -1170,30 +1170,25 @@ function printAttrs(path, options, print, { inline = false } = {}) {
     return [];
   }
   path.each(() => {
-    const attrGroup = ["#["];
+    const attrGroup = [];
     if (!inline && allAttrs.length > 0) {
       allAttrs.push(hardline);
     }
-    attrGroup.push(softline);
-    path.each(() => {
+    path.each((_, index) => {
       const attrNode = path.node;
-      if (attrGroup.length > 2) {
-        attrGroup.push(",", line);
-      }
       const attrStmt = [attrNode.name];
       if (attrNode.args.length > 0) {
         attrStmt.push(printArgumentsList(path, options, print, "args"));
       }
-      attrGroup.push(group(attrStmt));
+      if (index === 0) {
+        attrGroup.push("#[");
+      } else {
+        attrGroup.push(ifBreak([line, "#["], ", "));
+      }
+      attrGroup.push(group(attrStmt), ifBreak("]"));
     }, "attrs");
     allAttrs.push(
-      group([
-        indent(attrGroup),
-        ifBreak(shouldPrintComma(options, "8.0") ? "," : ""),
-        softline,
-        "]",
-        inline ? ifBreak(softline, " ") : "",
-      ])
+      group([attrGroup, ifBreak("", "]"), inline ? ifBreak(softline, " ") : ""])
     );
   }, "attrGroups");
   if (allAttrs.length === 0) {

--- a/tests/attributes-trail-comma/__snapshots__/jsfmt.spec.mjs.snap
+++ b/tests/attributes-trail-comma/__snapshots__/jsfmt.spec.mjs.snap
@@ -26,28 +26,24 @@ final class ORM
 =====================================output=====================================
 <?php
 
-#[
-    W(
-        "a",
-        null,
-        "looooong",
-        "paraaaams",
-        "list",
-        "aaaaaaaaaaaaa",
-        "vvvvvvvvvvvv",
-        "cccccccccc",
-        "eeeeeeeeeee",
-    ),
-    X,
-]
+#[W(
+    "a",
+    null,
+    "looooong",
+    "paraaaams",
+    "list",
+    "aaaaaaaaaaaaa",
+    "vvvvvvvvvvvv",
+    "cccccccccc",
+    "eeeeeeeeeee",
+)]
+#[X]
 final class ORM
 {
-    #[
-        ORM\\Column,
-        ORM\\CustomIdGenerator(class: "bar"),
-        ORM\\GeneratedValue(strategy: "CUSTOM"),
-        ORM\\Id,
-    ]
+    #[ORM\\Column]
+    #[ORM\\CustomIdGenerator(class: "bar")]
+    #[ORM\\GeneratedValue(strategy: "CUSTOM")]
+    #[ORM\\Id]
     private string $id;
 }
 

--- a/tests/attributes/__snapshots__/jsfmt.spec.mjs.snap
+++ b/tests/attributes/__snapshots__/jsfmt.spec.mjs.snap
@@ -61,6 +61,12 @@ final class DomainEventMessage
     }
 }
 
+// issue #2360
+#[Route('route/path', name: 'very_very_very_very_very_very_long_route_name', methods: ['GET'])]
+class Controller
+{
+}
+
 #[
     Attr1(Attr1::FOO | Attr1::BAR),
     Attr2(-20 * 5 + 10)
@@ -148,36 +154,30 @@ class D
     }
 }
 
-#[
-    W(
-        "a",
-        null,
-        "looooong",
-        "paraaaams",
-        "list",
-        "aaaaaaaaaaaaa",
-        "vvvvvvvvvvvv",
-        "cccccccccc",
-        "eeeeeeeeeee"
-    ),
-    X
-]
+#[W(
+    "a",
+    null,
+    "looooong",
+    "paraaaams",
+    "list",
+    "aaaaaaaaaaaaa",
+    "vvvvvvvvvvvv",
+    "cccccccccc",
+    "eeeeeeeeeee"
+)]
+#[X]
 function Y(
-    #[
-        ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ(
-            12345678,
-            1234578
-        )
-    ]
+    #[ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ(
+        12345678,
+        1234578
+    )]
     string $_
 ): string {
     return new #[NON, Anon] class {};
 }
 
-#[
-    IA("interface"),
-    \\Looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\\Namespace\\WithStuff\\IB
-]
+#[IA("interface")]
+#[\\Looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\\Namespace\\WithStuff\\IB]
 interface IC
 {
     #[ID]
@@ -202,15 +202,21 @@ final class DomainEventMessage
     }
 }
 
+// issue #2360
+#[Route(
+    "route/path",
+    name: "very_very_very_very_very_very_long_route_name",
+    methods: ["GET"]
+)]
+class Controller {}
+
 #[Attr1(Attr1::FOO | Attr1::BAR), Attr2(-20 * 5 + 10)]
 class A {}
 
 class ValueModel
 {
-    #[
-        Assert\\NotBlank(allowNull: false, groups: ["foo"]),
-        Assert\\Length(max: 255, groups: ["foo"])
-    ]
+    #[Assert\\NotBlank(allowNull: false, groups: ["foo"])]
+    #[Assert\\Length(max: 255, groups: ["foo"])]
     public ?string $value = null;
 }
 

--- a/tests/attributes/attributes.php
+++ b/tests/attributes/attributes.php
@@ -53,6 +53,12 @@ final class DomainEventMessage
     }
 }
 
+// issue #2360
+#[Route('route/path', name: 'very_very_very_very_very_very_long_route_name', methods: ['GET'])]
+class Controller
+{
+}
+
 #[
     Attr1(Attr1::FOO | Attr1::BAR),
     Attr2(-20 * 5 + 10)


### PR DESCRIPTION
This partially fixes #2360, in the sense that formatting now matches PSR guidelines. It will still split across multiple lines if need be though.