### PR TITLE
Update php-parser, fix unary snapshot tests, and make multiple fixes for attribute formatting.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "linguist-languages": "^8.0.0",
-    "php-parser": "^3.4.0"
+    "php-parser": "https://github.com/glayzzle/php-parser.git#0b3dbe8833965ae14915e722a1b974e3616df78c"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.27.2",
@@ -82,5 +82,6 @@
     "include": [
       "src/**"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,5 @@
     "include": [
       "src/**"
     ]
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@prettier/plugin-php",
-  "version": "0.25.0",
+  "name": "@vanilla/prettier-plugin-php",
+  "version": "0.26.0",
   "description": "Prettier PHP Plugin",
   "repository": "prettier/prettier-php",
   "author": "Lucas Azzola <@azz>",
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "linguist-languages": "^8.0.0",
-    "php-parser": "https://github.com/glayzzle/php-parser.git#0b3dbe8833965ae14915e722a1b974e3616df78c"
+    "php-parser": "^3.7.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.27.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@vanilla/prettier-plugin-php",
-  "version": "0.26.0",
+  "name": "@prettier/plugin-php",
+  "version": "0.25.0",
   "description": "Prettier PHP Plugin",
   "repository": "prettier/prettier-php",
   "author": "Lucas Azzola <@azz>",

--- a/src/comments.mjs
+++ b/src/comments.mjs
@@ -62,6 +62,7 @@ function handleOwnLineComment(comment, text, options) {
       options
     ) ||
     handleTryComments(enclosingNode, followingNode, comment) ||
+    handleClassMemberStatementComments(enclosingNode, followingNode, comment) ||
     handleClassComments(enclosingNode, followingNode, comment) ||
     handleFunctionParameter(
       text,
@@ -201,6 +202,7 @@ function handleRemainingComment(comment, text, options) {
     handleGoto(enclosingNode, comment) ||
     handleHalt(precedingNode, enclosingNode, followingNode, comment) ||
     handleBreakAndContinueStatementComments(enclosingNode, comment) ||
+    handleClassMemberStatementComments(enclosingNode, followingNode, comment) ||
     handleInlineComments(
       enclosingNode,
       precedingNode,
@@ -430,6 +432,32 @@ function handleTraitUseComments(enclosingNode, followingNode, comment) {
     addDanglingComment(enclosingNode, comment);
     return true;
   }
+  return false;
+}
+
+function handleClassMemberStatementComments(
+  enclosingNode,
+  followingNode,
+  comment
+) {
+  if (
+    enclosingNode &&
+    enclosingNode.kind === "propertystatement" &&
+    enclosingNode.properties?.includes(followingNode)
+  ) {
+    addLeadingComment(enclosingNode, comment);
+    return true;
+  }
+
+  if (
+    enclosingNode &&
+    enclosingNode.kind === "classconstant" &&
+    enclosingNode.constants?.includes(followingNode)
+  ) {
+    addLeadingComment(enclosingNode, comment);
+    return true;
+  }
+
   return false;
 }
 
@@ -906,6 +934,24 @@ function getCommentChildNodes(node) {
     // Pretend to be child of `class`
     node.what.__parent_new_arguments = [...node.arguments];
     return [node.what];
+  }
+
+  if (node.attrGroups && node.attrGroups.length > 0) {
+    if (node.kind === "method" || node.kind === "function") {
+      return [
+        ...node.attrGroups,
+        ...node.arguments,
+        ...(node.type ? [node.type] : []),
+      ];
+    }
+
+    if (node.kind === "classconstant") {
+      return [...node.attrGroups, ...node.constants];
+    }
+
+    if (node.kind === "enumcase") {
+      return node.attrGroups;
+    }
   }
 }
 

--- a/src/printer.mjs
+++ b/src/printer.mjs
@@ -1199,37 +1199,150 @@ function printAttrs(path, options, print, { inline = false } = {}) {
   if (!path.node.attrGroups) {
     return [];
   }
-  path.each(() => {
-    const attrGroup = ["#["];
+  path.each((attrGroupPath) => {
     if (!inline && allAttrs.length > 0) {
       allAttrs.push(hardline);
     }
-    attrGroup.push(softline);
-    path.each(() => {
-      const attrNode = path.node;
-      if (attrGroup.length > 2) {
-        attrGroup.push(",", line);
-      }
-      const attrStmt = [attrNode.name];
-      if (attrNode.args.length > 0) {
-        attrStmt.push(printArgumentsList(path, options, print, "args"));
-      }
-      attrGroup.push(group(attrStmt));
-    }, "attrs");
     allAttrs.push(
-      group([
-        indent(attrGroup),
-        ifBreak(shouldPrintComma(options, 8.0) ? "," : ""),
-        softline,
-        "]",
-        inline ? ifBreak(softline, " ") : "",
-      ])
+      printAllComments(
+        attrGroupPath,
+        () => printAttrGroup(attrGroupPath, options, print, { inline }),
+        options
+      )
     );
   }, "attrGroups");
   if (allAttrs.length === 0) {
     return [];
   }
   return [...allAttrs, inline ? "" : hardline];
+}
+
+function printAttrGroup(path, options, print, { inline = false } = {}) {
+  const attrGroup = ["#["];
+  attrGroup.push(softline);
+  path.each(() => {
+    const attrNode = path.node;
+    if (attrGroup.length > 2) {
+      attrGroup.push(",", line);
+    }
+    const attrStmt = [attrNode.name];
+    if (attrNode.args.length > 0) {
+      attrStmt.push(printArgumentsList(path, options, print, "args"));
+    }
+    attrGroup.push(group(attrStmt));
+  }, "attrs");
+  return group([
+    indent(attrGroup),
+    ifBreak(shouldPrintComma(options, 8.0) ? "," : ""),
+    softline,
+    "]",
+    inline ? ifBreak(softline, " ") : "",
+  ]);
+}
+
+function printFunction(path, options, print) {
+  const { node } = path;
+  const declAttrs = printAttrs(path, options, print, {
+    inline: node.kind === "closure",
+  });
+  const declaration = [];
+
+  if (node.isFinal) {
+    declaration.push("final ");
+  }
+
+  if (node.isAbstract) {
+    declaration.push("abstract ");
+  }
+
+  if (node.visibility) {
+    declaration.push(node.visibility, " ");
+  }
+
+  if (node.isStatic) {
+    declaration.push("static ");
+  }
+
+  declaration.push("function ");
+
+  if (node.byref) {
+    declaration.push("&");
+  }
+
+  if (node.name) {
+    declaration.push(print("name"));
+  }
+
+  declaration.push(printArgumentsList(path, options, print));
+
+  if (node.uses && node.uses.length > 0) {
+    declaration.push(
+      group([" use ", printArgumentsList(path, options, print, "uses")])
+    );
+  }
+
+  if (node.type) {
+    declaration.push([
+      ": ",
+      hasDanglingComments(node.type)
+        ? [
+            path.call(() => printDanglingComments(path, options, true), "type"),
+            " ",
+          ]
+        : "",
+      node.nullable ? "?" : "",
+      print("type"),
+    ]);
+  }
+
+  const printedDeclaration = declaration;
+
+  if (!node.body) {
+    return [...declAttrs, printedDeclaration];
+  }
+
+  const printedBody = [
+    "{",
+    indent([hasEmptyBody(path) ? "" : hardline, print("body")]),
+    hasEmptyBody(path) ? "" : hardline,
+    "}",
+  ];
+
+  const isClosure = node.kind === "closure";
+  if (isClosure) {
+    return [...declAttrs, printedDeclaration, " ", printedBody];
+  }
+
+  if (node.arguments.length === 0) {
+    return [
+      ...declAttrs,
+      printedDeclaration,
+      shouldPrintHardlineForOpenBrace(options) && !hasEmptyBody(path)
+        ? hardline
+        : " ",
+      printedBody,
+    ];
+  }
+
+  const willBreakDeclaration = declaration.some(willBreak);
+
+  if (willBreakDeclaration) {
+    return [...declAttrs, printedDeclaration, " ", printedBody];
+  }
+
+  return [
+    ...declAttrs,
+    conditionalGroup([
+      [
+        printedDeclaration,
+        shouldPrintHardlineForOpenBrace(options) && !hasEmptyBody(path)
+          ? hardline
+          : " ",
+        printedBody,
+      ],
+      [printedDeclaration, " ", printedBody],
+    ]),
+  ];
 }
 
 function printClass(path, options, print) {
@@ -1351,111 +1464,6 @@ function printClass(path, options, print) {
   ];
 
   return [printedDeclaration, printedBody];
-}
-
-function printFunction(path, options, print) {
-  const { node } = path;
-  const declAttrs = printAttrs(path, options, print, {
-    inline: node.kind === "closure",
-  });
-  const declaration = [];
-
-  if (node.isFinal) {
-    declaration.push("final ");
-  }
-
-  if (node.isAbstract) {
-    declaration.push("abstract ");
-  }
-
-  if (node.visibility) {
-    declaration.push(node.visibility, " ");
-  }
-
-  if (node.isStatic) {
-    declaration.push("static ");
-  }
-
-  declaration.push("function ");
-
-  if (node.byref) {
-    declaration.push("&");
-  }
-
-  if (node.name) {
-    declaration.push(print("name"));
-  }
-
-  declaration.push(printArgumentsList(path, options, print));
-
-  if (node.uses && node.uses.length > 0) {
-    declaration.push(
-      group([" use ", printArgumentsList(path, options, print, "uses")])
-    );
-  }
-
-  if (node.type) {
-    declaration.push([
-      ": ",
-      hasDanglingComments(node.type)
-        ? [
-            path.call(() => printDanglingComments(path, options, true), "type"),
-            " ",
-          ]
-        : "",
-      node.nullable ? "?" : "",
-      print("type"),
-    ]);
-  }
-
-  const printedDeclaration = declaration;
-
-  if (!node.body) {
-    return [...declAttrs, printedDeclaration];
-  }
-
-  const printedBody = [
-    "{",
-    indent([hasEmptyBody(path) ? "" : hardline, print("body")]),
-    hasEmptyBody(path) ? "" : hardline,
-    "}",
-  ];
-
-  const isClosure = node.kind === "closure";
-  if (isClosure) {
-    return [...declAttrs, printedDeclaration, " ", printedBody];
-  }
-
-  if (node.arguments.length === 0) {
-    return [
-      ...declAttrs,
-      printedDeclaration,
-      shouldPrintHardlineForOpenBrace(options) && !hasEmptyBody(path)
-        ? hardline
-        : " ",
-      printedBody,
-    ];
-  }
-
-  const willBreakDeclaration = declaration.some(willBreak);
-
-  if (willBreakDeclaration) {
-    return [...declAttrs, printedDeclaration, " ", printedBody];
-  }
-
-  return [
-    ...declAttrs,
-    conditionalGroup([
-      [
-        printedDeclaration,
-        shouldPrintHardlineForOpenBrace(options) && !hasEmptyBody(path)
-          ? hardline
-          : " ",
-        printedBody,
-      ],
-      [printedDeclaration, " ", printedBody],
-    ]),
-  ];
 }
 
 function printBodyControlStructure(
@@ -2909,6 +2917,7 @@ function printNode(path, options, print) {
 
     case "enumcase":
       return group([
+        ...printAttrs(path, options, print),
         "case ",
         print("name"),
         node.value

--- a/src/printer.mjs
+++ b/src/printer.mjs
@@ -1240,111 +1240,6 @@ function printAttrGroup(path, options, print, { inline = false } = {}) {
   ]);
 }
 
-function printFunction(path, options, print) {
-  const { node } = path;
-  const declAttrs = printAttrs(path, options, print, {
-    inline: node.kind === "closure",
-  });
-  const declaration = [];
-
-  if (node.isFinal) {
-    declaration.push("final ");
-  }
-
-  if (node.isAbstract) {
-    declaration.push("abstract ");
-  }
-
-  if (node.visibility) {
-    declaration.push(node.visibility, " ");
-  }
-
-  if (node.isStatic) {
-    declaration.push("static ");
-  }
-
-  declaration.push("function ");
-
-  if (node.byref) {
-    declaration.push("&");
-  }
-
-  if (node.name) {
-    declaration.push(print("name"));
-  }
-
-  declaration.push(printArgumentsList(path, options, print));
-
-  if (node.uses && node.uses.length > 0) {
-    declaration.push(
-      group([" use ", printArgumentsList(path, options, print, "uses")])
-    );
-  }
-
-  if (node.type) {
-    declaration.push([
-      ": ",
-      hasDanglingComments(node.type)
-        ? [
-            path.call(() => printDanglingComments(path, options, true), "type"),
-            " ",
-          ]
-        : "",
-      node.nullable ? "?" : "",
-      print("type"),
-    ]);
-  }
-
-  const printedDeclaration = declaration;
-
-  if (!node.body) {
-    return [...declAttrs, printedDeclaration];
-  }
-
-  const printedBody = [
-    "{",
-    indent([hasEmptyBody(path) ? "" : hardline, print("body")]),
-    hasEmptyBody(path) ? "" : hardline,
-    "}",
-  ];
-
-  const isClosure = node.kind === "closure";
-  if (isClosure) {
-    return [...declAttrs, printedDeclaration, " ", printedBody];
-  }
-
-  if (node.arguments.length === 0) {
-    return [
-      ...declAttrs,
-      printedDeclaration,
-      shouldPrintHardlineForOpenBrace(options) && !hasEmptyBody(path)
-        ? hardline
-        : " ",
-      printedBody,
-    ];
-  }
-
-  const willBreakDeclaration = declaration.some(willBreak);
-
-  if (willBreakDeclaration) {
-    return [...declAttrs, printedDeclaration, " ", printedBody];
-  }
-
-  return [
-    ...declAttrs,
-    conditionalGroup([
-      [
-        printedDeclaration,
-        shouldPrintHardlineForOpenBrace(options) && !hasEmptyBody(path)
-          ? hardline
-          : " ",
-        printedBody,
-      ],
-      [printedDeclaration, " ", printedBody],
-    ]),
-  ];
-}
-
 function printClass(path, options, print) {
   const { node } = path;
   const isAnonymousClass = node.kind === "class" && node.isAnonymous;
@@ -1464,6 +1359,111 @@ function printClass(path, options, print) {
   ];
 
   return [printedDeclaration, printedBody];
+}
+
+function printFunction(path, options, print) {
+  const { node } = path;
+  const declAttrs = printAttrs(path, options, print, {
+    inline: node.kind === "closure",
+  });
+  const declaration = [];
+
+  if (node.isFinal) {
+    declaration.push("final ");
+  }
+
+  if (node.isAbstract) {
+    declaration.push("abstract ");
+  }
+
+  if (node.visibility) {
+    declaration.push(node.visibility, " ");
+  }
+
+  if (node.isStatic) {
+    declaration.push("static ");
+  }
+
+  declaration.push("function ");
+
+  if (node.byref) {
+    declaration.push("&");
+  }
+
+  if (node.name) {
+    declaration.push(print("name"));
+  }
+
+  declaration.push(printArgumentsList(path, options, print));
+
+  if (node.uses && node.uses.length > 0) {
+    declaration.push(
+      group([" use ", printArgumentsList(path, options, print, "uses")])
+    );
+  }
+
+  if (node.type) {
+    declaration.push([
+      ": ",
+      hasDanglingComments(node.type)
+        ? [
+            path.call(() => printDanglingComments(path, options, true), "type"),
+            " ",
+          ]
+        : "",
+      node.nullable ? "?" : "",
+      print("type"),
+    ]);
+  }
+
+  const printedDeclaration = declaration;
+
+  if (!node.body) {
+    return [...declAttrs, printedDeclaration];
+  }
+
+  const printedBody = [
+    "{",
+    indent([hasEmptyBody(path) ? "" : hardline, print("body")]),
+    hasEmptyBody(path) ? "" : hardline,
+    "}",
+  ];
+
+  const isClosure = node.kind === "closure";
+  if (isClosure) {
+    return [...declAttrs, printedDeclaration, " ", printedBody];
+  }
+
+  if (node.arguments.length === 0) {
+    return [
+      ...declAttrs,
+      printedDeclaration,
+      shouldPrintHardlineForOpenBrace(options) && !hasEmptyBody(path)
+        ? hardline
+        : " ",
+      printedBody,
+    ];
+  }
+
+  const willBreakDeclaration = declaration.some(willBreak);
+
+  if (willBreakDeclaration) {
+    return [...declAttrs, printedDeclaration, " ", printedBody];
+  }
+
+  return [
+    ...declAttrs,
+    conditionalGroup([
+      [
+        printedDeclaration,
+        shouldPrintHardlineForOpenBrace(options) && !hasEmptyBody(path)
+          ? hardline
+          : " ",
+        printedBody,
+      ],
+      [printedDeclaration, " ", printedBody],
+    ]),
+  ];
 }
 
 function printBodyControlStructure(

--- a/tests/attributes/__snapshots__/jsfmt.spec.mjs.snap
+++ b/tests/attributes/__snapshots__/jsfmt.spec.mjs.snap
@@ -134,12 +134,12 @@ class D
     function k(#[L] int $m): callable
     {
         return #[N, O] #[P] fn(#[Q] int $r) => $r * 2;
-    } //Testing T
+    }
 
     // Testing S
-    //Testing S-T
     #[S]
-    #[T]
+    //Testing S-T
+    #[T] //Testing T
     private function u()
     {
         return #[V] function () {

--- a/tests/comments/__snapshots__/jsfmt.spec.mjs.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.mjs.snap
@@ -4922,9 +4922,9 @@ class Foo
 
     public function emptyMethod(/* comments */) {}
 
-    abstract public function sortByName(/* bool $useNaturalSort = false */); /* comment */
+    abstract public function sortByName(/* bool $useNaturalSort = false */);
 
-    /* comment */ /* comment */ protected static $foo; /* comment */
+    /* comment */ /* comment */ /* comment */ protected static $foo; /* comment */
 
     public function foo() {} // Comment
 

--- a/tests/enum/__snapshots__/jsfmt.spec.mjs.snap
+++ b/tests/enum/__snapshots__/jsfmt.spec.mjs.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`enum.php 1`] = `
 ====================================options=====================================
@@ -140,6 +140,52 @@ enum BackedSuit: string
 
 class Enum {}
 class Enum extends Foo {}
+
+================================================================================
+`;
+
+exports[`enum-case-attributes.php 1`] = `
+====================================options=====================================
+parsers: ["php"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<?php
+
+namespace App\\Enums;
+
+use App\\Support\\Attributes\\Description;
+
+enum SalutationEnum: string
+{
+    #[Description('Mr.')]
+    case MR = 'mr';
+
+    #[Description('Mrs.')]
+    case MRS = 'mrs';
+
+    #[Description('Miss')]
+    case MISS = 'miss';
+}
+
+=====================================output=====================================
+<?php
+
+namespace App\\Enums;
+
+use App\\Support\\Attributes\\Description;
+
+enum SalutationEnum: string
+{
+    #[Description("Mr.")]
+    case MR = "mr";
+
+    #[Description("Mrs.")]
+    case MRS = "mrs";
+
+    #[Description("Miss")]
+    case MISS = "miss";
+}
 
 ================================================================================
 `;

--- a/tests/enum/enum-case-attributes.php
+++ b/tests/enum/enum-case-attributes.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Enums;
+
+use App\Support\Attributes\Description;
+
+enum SalutationEnum: string
+{
+    #[Description('Mr.')]
+    case MR = 'mr';
+
+    #[Description('Mrs.')]
+    case MRS = 'mrs';
+
+    #[Description('Miss')]
+    case MISS = 'miss';
+}

--- a/tests/parens/__snapshots__/jsfmt.spec.mjs.snap
+++ b/tests/parens/__snapshots__/jsfmt.spec.mjs.snap
@@ -1300,7 +1300,7 @@ $var = $var + $var ** 2;
 $var = ($var + $var) ** 2;
 $var = $var + $var ** 2;
 $var = (+$var) ** 2;
-$var = (+$var) ** 2;
+$var = +($var ** 2);
 
 $var = $foo instanceof Foo;
 $var = $foo instanceof Foo || $foo instanceof Foo;
@@ -2067,7 +2067,7 @@ $var = $var + $var ** 2;
 $var = ($var + $var) ** 2;
 $var = $var + $var ** 2;
 $var = (+$var) ** 2;
-$var = (+$var) ** 2;
+$var = +($var ** 2);
 
 $var = $foo instanceof Foo;
 $var = $foo instanceof Foo || $foo instanceof Foo;
@@ -6574,7 +6574,7 @@ $var = ~~$var;
 $var = !$var;
 $var = !!$var;
 
-$a = (+$a) ** 1;
+$a = +($a ** 1);
 $a = (+$a) ** 1;
 $a = 1 ** +$a;
 
@@ -6718,7 +6718,7 @@ $var = ~~$var;
 $var = !$var;
 $var = !!$var;
 
-$a = (+$a) ** 1;
+$a = +($a ** 1);
 $a = (+$a) ** 1;
 $a = 1 ** +$a;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5737,9 +5737,10 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-"php-parser@https://github.com/glayzzle/php-parser.git#0b3dbe8833965ae14915e722a1b974e3616df78c":
-  version "3.6.0"
-  resolved "https://github.com/glayzzle/php-parser.git#0b3dbe8833965ae14915e722a1b974e3616df78c"
+php-parser@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/php-parser/-/php-parser-3.7.0.tgz#b40b82dc9ba2ad3068b418130f50a84b663d29ac"
+  integrity sha512-JRc1t78GZAEa+MuzVC5A5RJS1NDFTS4UnprUEu/NnsN9cyHbGZLUqghO9IQZUSCay62HYQiWd3PxyWAEF45zmA==
 
 picocolors@^1.1.1:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5737,10 +5737,9 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-php-parser@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/php-parser/-/php-parser-3.4.0.tgz#dcd7743bf01caaaa7281e8b253f4cdbbea6e1265"
-  integrity sha512-JoDPazv8OESrVtcoIuO8HC587zVNJYSYUIl9zYn+JEpwlHSOrxmyMHB+sDS0O1ID5z1aFxPnr+vAUGoSKphlHA==
+"php-parser@https://github.com/glayzzle/php-parser.git#0b3dbe8833965ae14915e722a1b974e3616df78c":
+  version "3.6.0"
+  resolved "https://github.com/glayzzle/php-parser.git#0b3dbe8833965ae14915e722a1b974e3616df78c"
 
 picocolors@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
Fixes https://github.com/prettier/plugin-php/issues/2293
Fixes https://github.com/prettier/plugin-php/issues/2486

## Dependency update note

This PR relies on a new version of php-parser: 3.7.0.

I was initially setting out to just fix the attribute formatting issues, but that required a new version of the php-parser. Unfortunately the currently published 3.6 has a regression around the unary operator reported as #2486 which means we can't just update to that.

## Attribute formatting fixes

Fixes https://github.com/prettier/plugin-php/issues/2293

The updated `php-parser` exposes attribute groups as distinct AST nodes on methods, functions, class constants, and enum cases. I madechanges so attributes and their comments format correctly.

**Changes**

- **`getCommentChildNodes`** — attribute groups are now comment attachment targets on `function`/`method`, `classconstant`, and `enumcase`, so comments between `#[...]` blocks attach to the right node instead of being skipped or misplaced.
- **`printAttrs` / `printAttrGroup`** — each attribute group is printed through `printAllComments()`, so leading and trailing comments on groups are actually emitted.
- **`enumcase` printing** — attributes on enum cases are now printed before `case` (new coverage in `tests/enum/enum-case-attributes.php`).
- **`handleClassMemberStatementComments`** — comments before a property or constant identifier are attached to the enclosing member statement, keeping modifiers like `public static` together when comments appear between modifiers and the name.

**Snapshot impact**

| Test | What changed |
|------|--------------|
| `tests/attributes/attributes.php` | Comments between `#[S]` and `#[T]` now print in place; `//Testing T` no longer incorrectly trails the previous method's `}`. |
| `tests/comments/method.php` | Dangling comment in empty `()` stays inside parens; inline comments between `static` and `$foo` are all preserved. |
| `tests/enum/enum-case-attributes.php` | New snapshot for attributed enum cases. |


---

## Unary operator / exponentiation fix (upstream parser)

Fixes https://github.com/prettier/plugin-php/issues/2486

This change comes from `php-parser`, not from new formatting logic in the plugin. PHP gives `**` higher precedence than unary `+` and `-`, so unparenthesized expressions parse differently from explicitly parenthesized ones:

```php
+$a ** 1   // PHP parses as:  +($a ** 1)
(+$a) ** 1 // PHP parses as:  (+$a) ** 1
```

The old parser incorrectly parsed `+$var ** 2` as `(+$var) ** 2`. The formatter faithfully reproduced that wrong AST, so both forms printed identically. The updated parser builds the correct tree — unary wrapping exponentiation for the unparenthesized form, and a `bin(**)` with `parenthesizedExpression: true` when parens are explicit.

Only the snapshots needed updating.

**Snapshot impact**

| Test | Input | Old output | New output |
|------|-------|------------|------------|
| `tests/parens/bin.php` | `$var = +$var ** 2;` | `(+$var) ** 2` | `+($var ** 2)` |
| `tests/parens/unary.php` | `$a = +$a ** 1;` | `(+$a) ** 1` | `+($a ** 1)` |

Explicitly parenthesized inputs such as `(+$var) ** 2` and `(+$a) ** 1` are unchanged.

This is a semantic correction: the old output did not match how PHP actually parses unparenthesized `+$x ** n` expressions.


